### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# bakend-api-eds
+# backend-api-eds
 docker Net8


### PR DESCRIPTION
## Summary
- fix a spelling mistake in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7e47f228832ba62f8ba636980fd4