### PR TITLE
add price per gallons

### DIFF
--- a/Poliedro.Eds.Domain/Hose/Dtos/HoseDto.cs
+++ b/Poliedro.Eds.Domain/Hose/Dtos/HoseDto.cs
@@ -11,6 +11,7 @@ public record HoseDto(
     double AccumulatedGallons,
     double AccumulatedAmount,
     int IdProductType,
+    double Price,
     DispensersEntity dispensersEntity,
     ProductTypeEntity productTypeEntity,
     EdsEntity edsEntity

--- a/Poliedro.Eds.Domain/Hose/Entities/HoseEntity.cs
+++ b/Poliedro.Eds.Domain/Hose/Entities/HoseEntity.cs
@@ -1,7 +1,4 @@
-﻿using Poliedro.Eds.Domain.Dispensers.Entities;
-using Poliedro.Eds.Domain.ProductType.Entities;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace Poliedro.Eds.Domain.Hose.Entities;
 
@@ -14,4 +11,5 @@ public class HoseEntity
     public double AccumulatedGallons { get; set; }
     public double AccumulatedAmount { get; set; }
     public int IdProductType { get; set; }
+    public double Price { get; set; }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
@@ -21,6 +21,8 @@ public class HoseGetAllHose(DataBaseContext context, IRedisService redisService)
                     join dispenser in context.Dispensers on hose.IdDispensers equals dispenser.Id
                     join productType in context.ProductTypes on hose.IdProductType equals productType.IdProductType
                     join eds in context.Eds on dispenser.EdsId equals eds.IdEds
+                    join product in context.Product on hose.IdProductType equals product.IdProductType
+                    
                     select new HoseDto(
                         hose.IdHose,
                         hose.Number,
@@ -28,6 +30,7 @@ public class HoseGetAllHose(DataBaseContext context, IRedisService redisService)
                         hose.AccumulatedGallons,
                         hose.AccumulatedAmount,
                         hose.IdProductType,
+                        product.Price,
                         dispenser,
                         productType,
                         eds


### PR DESCRIPTION
## Summary by Sourcery

Add a price-per-gallon field to hoses by extending the domain entity, DTO, and data access query to include product price

New Features:
- Expose a Price property on HoseEntity to track price per gallon
- Include Price in the HoseDto signature
- Join the Product table in HoseGetAllHose to fetch and project the price

Enhancements:
- Remove unused usings from HoseEntity