### PR TITLE
Persistence Inventory

### DIFF
--- a/Poliedro.Eds.Application/Court/AutoMappers/CourtMapper.cs
+++ b/Poliedro.Eds.Application/Court/AutoMappers/CourtMapper.cs
@@ -28,6 +28,8 @@ namespace Poliedro.Eds.Application.Court.AutoMappers
              .ForMember(dest => dest.IdProduct, opt => opt.MapFrom(src => src.IdProduct));
             CreateMap<CourtDispenserCommand, ICourtDispenserSaleEntity>()
              .ForMember(dest => dest.GallonsDifferenceResult, opt => opt.MapFrom(src => src.GallonsDifferenceResult));
+            CreateMap<CourtInventoryEntity, CourtInventoryDto>().ReverseMap();
+            CreateMap<CourtInventoryEntity, CourtInventoryCommand>().ReverseMap();
         }
     }
 }

--- a/Poliedro.Eds.Application/Court/Commands/CreateCourt/CourtInventoryCommand.cs
+++ b/Poliedro.Eds.Application/Court/Commands/CreateCourt/CourtInventoryCommand.cs
@@ -1,0 +1,8 @@
+namespace Poliedro.Eds.Application.Court.Commands.CreateCourt;
+
+public record CourtInventoryCommand
+(
+    DateOnly Date,
+    string ReferenceType,
+    int ReferenceId
+);

--- a/Poliedro.Eds.Application/Court/Commands/CreateCourt/CreateCourtCommand.cs
+++ b/Poliedro.Eds.Application/Court/Commands/CreateCourt/CreateCourtCommand.cs
@@ -17,6 +17,7 @@ public record CreateCourtCommand(
     IEnumerable<CourtDispenserCommand> CourtDispensers,
     IEnumerable<DocumentCommand> CourtDocuments,
     IEnumerable<CourtExpenditureCommand> CourtExpenditures,
-    IEnumerable<CourtTypeOfCollectionCommand> CourtTypeOfCollections
+    IEnumerable<CourtTypeOfCollectionCommand> CourtTypeOfCollections,
+    CourtInventoryCommand? CourtInventory
     ) : IRequest<Result<VoidResult, Error>>;
 

--- a/Poliedro.Eds.Application/Court/Commands/CreateCourt/Handler/CreateCourtCommandHandle.cs
+++ b/Poliedro.Eds.Application/Court/Commands/CreateCourt/Handler/CreateCourtCommandHandle.cs
@@ -69,6 +69,12 @@ namespace Poliedro.Eds.Application.Court.Commands.CreateCourt.Handler
                 }
             }
 
+            courtEntity.CourtInventory = new CourtInventoryEntity
+            {
+                Date = courtEntity.DateStarttime,
+                ReferenceType = "court",
+            };
+
 
             var result = await courtDomainService.CreateAsync(courtEntity);
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Application/Court/Dtos/CourtDto.cs
+++ b/Poliedro.Eds.Application/Court/Dtos/CourtDto.cs
@@ -16,5 +16,7 @@
         public IEnumerable<DocumentDto> CourtDocuments{ get; set; }
         public IEnumerable<CourtExpenditureDto> CourtExpenditures { get; set; }
         public IEnumerable<CourtTypeOfCollectionDto> CourtTypeOfCollections { get; set; }
+        public CourtInventoryDto? CourtInventory { get; set; }
+
     }
 }

--- a/Poliedro.Eds.Application/Court/Dtos/CourtInventoryDto.cs
+++ b/Poliedro.Eds.Application/Court/Dtos/CourtInventoryDto.cs
@@ -1,0 +1,10 @@
+namespace Poliedro.Eds.Application.Court.Dtos
+{
+    public class CourtInventoryDto
+    {
+        public int IdInventory { get; set; }
+        public DateOnly Date { get; set; }
+        public string ReferenceType { get; set; }
+        public int ReferenceId { get; set; }
+    }
+}

--- a/Poliedro.Eds.Domain/Court/Entities/CourtEntity.cs
+++ b/Poliedro.Eds.Domain/Court/Entities/CourtEntity.cs
@@ -16,4 +16,5 @@ public class CourtEntity
     public IEnumerable<DocumentEntity> CourtDocuments { get; set; }
     public IEnumerable<CourtExpenditureEntity> CourtExpenditures { get; set; }
     public IEnumerable<CourtTypeOfCollectionEntity> CourtTypeOfCollections { get; set; }
+    public CourtInventoryEntity CourtInventory { get; set; }
 }

--- a/Poliedro.Eds.Domain/Court/Entities/CourtInventoryEntity.cs
+++ b/Poliedro.Eds.Domain/Court/Entities/CourtInventoryEntity.cs
@@ -1,0 +1,9 @@
+namespace Poliedro.Eds.Domain.Court.Entities;
+
+public class CourtInventoryEntity
+{
+    public int IdInventory { get; set; }
+    public DateOnly Date { get; set; }
+    public string ReferenceType { get; set; }
+    public int ReferenceId { get; set; }
+}

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Context/DataBaseContext.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Context/DataBaseContext.cs
@@ -33,6 +33,7 @@ public class DataBaseContext(DbContextOptions options) : DbContext(options)
 {
     public DbSet<ProductTypeEntity> ProductType { get; set; }
     public DbSet<CourtEntity> Court { get; set; }
+    public DbSet<CourtInventoryEntity> CourtInventory { get; set; }
     public DbSet<BusinessEntity> Business { get; set; }
     public DbSet<CapacityEntity> Capacity { get; set; }
     public DbSet<EdsEntity> Eds { get; set; }
@@ -81,6 +82,7 @@ public class DataBaseContext(DbContextOptions options) : DbContext(options)
         new CourtExpendituresConfiguration(modelBuilder.Entity<CourtExpenditureEntity>());
         new CourtTypeOfCollectionsConfiguration(modelBuilder.Entity<CourtTypeOfCollectionEntity>());
         new DocumentConfiguration(modelBuilder.Entity<DocumentEntity>());
+        new CourtInventoryConfiguration(modelBuilder.Entity<CourtInventoryEntity>());
         new IslanderConfiguration(modelBuilder.Entity<IslanderEntity>());
         new IslandConfiguration(modelBuilder.Entity<IslandEntity>());
         new DispensersConfiguration(modelBuilder.Entity<DispensersEntity>());

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/CourtConfiguration.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/CourtConfiguration.cs
@@ -22,12 +22,15 @@ public class CourtConfiguration
         builder.Property(x => x.Descripcion).HasColumnName("descripcion");
         builder.Property(x => x.Distintic).HasColumnName("distintic");
 
+        builder.HasOne(x => x.CourtInventory)
+                .WithOne()
+                .HasForeignKey<CourtInventoryEntity>(x => x.ReferenceId);
         builder.HasMany(x => x.CourtDispensers)
-       .WithOne()
-       .HasForeignKey(x => x.IdCourt);
+                .WithOne()
+                .HasForeignKey(x => x.IdCourt);
 
         builder.HasMany(x => x.CourtDocuments)
-               .WithOne()
+                .WithOne()
                .HasForeignKey(x => x.IdCourt);
 
         builder.HasMany(x => x.CourtExpenditures)
@@ -37,5 +40,7 @@ public class CourtConfiguration
         builder.HasMany(x => x.CourtTypeOfCollections)
                .WithOne()
                .HasForeignKey(x => x.IdCourt);
+        
+
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/CourtInventoryConfiguration.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/CourtInventoryConfiguration.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Poliedro.Eds.Domain.Court.Entities;
+
+namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.EntityFramework.EntityConfigurations
+{
+    public class CourtInventoryConfiguration
+    {
+        public CourtInventoryConfiguration(EntityTypeBuilder<CourtInventoryEntity> builder)
+        {
+            builder.ToTable("inventory");
+            builder.HasKey(x => x.IdInventory);
+            builder.Property(x => x.IdInventory).HasColumnName("id_inventory");
+            builder.Property(x => x.Date).HasColumnName("date");
+            builder.Property(x => x.ReferenceType).HasColumnName("reference_type");
+            builder.Property(x => x.ReferenceId).HasColumnName("reference_id");
+        }
+    }
+}

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Poliedro.Eds.Infraestructure.Persistence.Mysql.csproj
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Poliedro.Eds.Infraestructure.Persistence.Mysql.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <Folder Include="Inventory\DomainService\Impl\" />
+    <Folder Include="ScriptMySQL\" />
   </ItemGroup>
 
 </Project>

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/ScriptMySQL/Trigger persistence accumulated in hose.sql
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/ScriptMySQL/Trigger persistence accumulated in hose.sql
@@ -1,0 +1,15 @@
+DROP TRIGGER IF EXISTS trg_update_hose_accumulated;
+DELIMITER $$
+
+CREATE TRIGGER trg_update_hose_accumulated
+AFTER INSERT ON court_dispensers
+FOR EACH ROW
+BEGIN
+    UPDATE hose
+    SET 
+        accumulated_amount = NEW.accumulated_amount,
+        accumulated_gallons = NEW.accumulated_gallons
+    WHERE id_hose = NEW.id_hose;
+END$$
+
+DELIMITER ;

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/ScriptMySQL/Trigger persistence in court_dispensers_inventory.sql
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/ScriptMySQL/Trigger persistence in court_dispensers_inventory.sql
@@ -1,0 +1,24 @@
+DROP TRIGGER IF EXISTS trg_insert_court_dispensers_inventory_from_inventory;
+DELIMITER $$
+
+CREATE TRIGGER trg_insert_court_dispensers_inventory_from_inventory
+AFTER INSERT ON inventory
+FOR EACH ROW
+BEGIN
+    DECLARE v_id_court INT;
+
+    SELECT id_court INTO v_id_court
+    FROM court
+    WHERE id_court = NEW.reference_id
+    AND 'court' = NEW.reference_type;
+
+    INSERT INTO court_dispensers_inventory (
+        id_court_dispensers,
+        id_inventory
+    )
+    SELECT id_court_dispensers, NEW.id_inventory
+    FROM court_dispensers
+    WHERE id_court = v_id_court;
+END$$
+
+DELIMITER ;

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/ScriptMySQL/Trigger persistence in hose_history.sql
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/ScriptMySQL/Trigger persistence in hose_history.sql
@@ -1,0 +1,34 @@
+DROP TRIGGER IF EXISTS trg_insert_hose_history;
+DELIMITER $$
+
+CREATE TRIGGER trg_insert_hose_history
+AFTER INSERT ON court_dispensers
+FOR EACH ROW
+BEGIN
+    DECLARE court_date DATE;
+    DECLARE v_id_dispensers INT;
+
+    SELECT date_starttime INTO court_date
+    FROM court
+    WHERE id_court = NEW.id_court;
+
+    SELECT id_dispensers INTO v_id_dispensers
+    FROM hose
+    WHERE id_hose = NEW.id_hose;
+
+    INSERT INTO hose_history (
+        id_hose,
+        id_dispensers,
+        accumulated_amount,
+        accumulated_gallons,
+        date
+    ) VALUES (
+        NEW.id_hose,
+        v_id_dispensers,
+        NEW.accumulated_amount,
+        NEW.accumulated_gallons,
+        court_date
+    );
+END$$
+
+DELIMITER ;

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/ScriptMySQL/Trigger stock persistence.sql
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/ScriptMySQL/Trigger stock persistence.sql
@@ -1,0 +1,16 @@
+DROP TRIGGER IF EXISTS after_insert_shopping_product;
+DELIMITER $$
+CREATE TRIGGER after_insert_shopping_product
+AFTER INSERT ON shopping_product
+FOR EACH ROW
+BEGIN
+  UPDATE product_compartiment
+  SET stock = stock + NEW.quantity
+  WHERE id_product = NEW.id_product
+    AND id_compartiment = NEW.id_compartiment;
+
+  UPDATE compartiment
+  SET stock = stock + NEW.quantity
+  WHERE id_compartiment = NEW.id_compartiment;
+END $$
+DELIMITER ;

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/ScriptMySQL/Triggers persistence in tank.sql
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/ScriptMySQL/Triggers persistence in tank.sql
@@ -1,0 +1,77 @@
+DELIMITER $$
+CREATE TRIGGER after_update_product_compartiment
+AFTER UPDATE ON product_compartiment
+FOR EACH ROW
+BEGIN
+  DECLARE tankIdNew INT;
+  DECLARE tankIdOld INT;
+
+  -- Nuevo tanque relacionado
+  SELECT id_tank INTO tankIdNew FROM compartiment WHERE id_compartiment = NEW.id_compartiment;
+  UPDATE tank
+    SET stock = (
+      SELECT IFNULL(SUM(pc.stock),0)
+      FROM product_compartiment pc
+      JOIN compartiment c ON c.id_compartiment = pc.id_compartiment
+      WHERE c.id_tank = tank.id_tank
+    )
+    WHERE id_tank = tankIdNew;
+
+  -- Si el compartimiento cambió de tanque, actualizar el anterior también
+  IF (OLD.id_compartiment <> NEW.id_compartiment) THEN
+    SELECT id_tank INTO tankIdOld FROM compartiment WHERE id_compartiment = OLD.id_compartiment;
+    UPDATE tank
+      SET stock = (
+        SELECT IFNULL(SUM(pc.stock),0)
+        FROM product_compartiment pc
+        JOIN compartiment c ON c.id_compartiment = pc.id_compartiment
+        WHERE c.id_tank = tank.id_tank
+      )
+      WHERE id_tank = tankIdOld;
+  END IF;
+END $$
+DELIMITER ;
+
+
+DROP TRIGGER IF EXISTS after_insert_product_compartiment;
+DELIMITER $$
+CREATE TRIGGER after_insert_product_compartiment
+AFTER INSERT ON product_compartiment
+FOR EACH ROW
+BEGIN
+  DECLARE tankId INT;
+  -- Obtener el id_tank relacionado con el nuevo compartimiento
+  SELECT id_tank INTO tankId FROM compartment WHERE id_compartiment = NEW.id_compartiment;
+  UPDATE tank
+    SET stock = (
+      SELECT IFNULL(SUM(pc.stock),0)
+      FROM product_compartiment pc
+      JOIN compartment c ON c.id_compartiment = pc.id_compartiment
+      WHERE c.id_tank = tank.id_tank
+    )
+    WHERE id_tank = tankId;
+END $$
+DELIMITER ;
+
+
+
+DROP TRIGGER IF EXISTS after_delete_product_compartiment;
+DELIMITER $$
+CREATE TRIGGER after_delete_product_compartiment
+AFTER DELETE ON product_compartiment
+FOR EACH ROW
+BEGIN
+  DECLARE tankId INT;
+  -- Obtener el id_tank relacionado con el compartimiento eliminado
+  SELECT id_tank INTO tankId FROM compartment WHERE id_compartiment = OLD.id_compartiment;
+  UPDATE tank
+    SET stock = (
+      SELECT IFNULL(SUM(pc.stock),0)
+      FROM product_compartiment pc
+      JOIN compartment c ON c.id_compartiment = pc.id_compartiment
+      WHERE c.id_tank = tank.id_tank
+    )
+    WHERE id_tank = tankId;
+END $$
+DELIMITER ;
+


### PR DESCRIPTION
## Summary by Sourcery

Introduce CourtInventory support and automate inventory persistence across database operations.

New Features:
- Add CourtInventory domain entity, DTO, command and mapper to application layer.
- Extend CreateCourtCommand and handler to initialize a CourtInventory record per court.
- Configure EF Core one-to-one relationship between Court and CourtInventory and register the DbSet.

Enhancements:
- Register CourtInventory table mapping in the DB context and EntityConfiguration.
- Add MySQL triggers to maintain related stocks and history in tanks, hoses, court dispensers and shopping products based on inventory and compartment changes.