### PR TITLE
ok health

### DIFF
--- a/Poliedro.Eds.Api/Program.cs
+++ b/Poliedro.Eds.Api/Program.cs
@@ -9,6 +9,7 @@ using FluentValidation;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
@@ -58,8 +59,12 @@ builder.Services
     .AddExternalTolgee();
 
 builder.Services.AddHostedService<Worker>();
+var httpContextAccessor = new HttpContextAccessor();
+var tenant = httpContextAccessor.HttpContext?.Items["tenant"]?.ToString();
+var connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? builder.Configuration["ConnectionStrings:MysqlConnection"];
+var connectionStringFactory = connectionString.Replace("{schema}", tenant);
 builder.Services.AddHealthChecks()
-    .AddMySql(builder.Configuration.GetConnectionString("MysqlConnection"), name: "sql", tags: ["ready"])
+    .AddMySql(connectionStringFactory, name: "sql", tags: ["ready"])
     .AddRedis(builder.Configuration["Redis:ConnectionString"], name: "redis", tags: ["ready"])
     .AddCheck<TolgeeHealthCheckService>("Service Health Check Tolgee"); 
 


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Apply dynamic multi-tenant configuration to the MySQL health check by extracting a tenant ID from HttpContext, replacing the `{schema}` placeholder in the connection string, and allowing an environment variable override.

Enhancements:
- Add HttpContextAccessor to retrieve the current tenant ID from HttpContext items
- Allow fallback to an environment variable for the MySQL connection string
- Replace the static MySQL connection string in the health check with a dynamically constructed string that injects the tenant schema placeholder