### PR TITLE
add AWS credentials setup step in deploy job

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -168,6 +168,13 @@ jobs:
     environment: QA
 
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Deploy to Amazon ECS
         run: |
           # Usar el ARN de la task definition desde Secrets


### PR DESCRIPTION
### Checklist antes de hacer merge

- [x] Code compiles correctly  
- [x] Tests have been added  
- [x] Documentation has been updated  
- [x] Team has been informed about the changes

## Summary by Sourcery

CI:
- Configure AWS credentials using aws-actions/configure-aws-credentials before deploying to ECS