### PR TITLE
Ok TolgeeService

### DIFF
--- a/Poliedro.Eds.Api/Program.cs
+++ b/Poliedro.Eds.Api/Program.cs
@@ -23,6 +23,7 @@ using Poliedro.Eds.Application.AWS.Configurations.Dto.Plemsi;
 using Poliedro.Eds.Application.Court.Queris.GetCourtList;
 using Poliedro.Eds.Application.FileUploadS3.Command;
 using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Application.Ports.Translations;
 using Poliedro.Eds.Application.Secrets.Aws.Dto;
 using Poliedro.Eds.Application.Translations.Dtos;
 using Poliedro.Eds.Application.Translations.Handle;
@@ -43,6 +44,8 @@ using System.Net.Http.Headers;
 using WorkerKeycloackService;
 
 var builder = WebApplication.CreateBuilder(args);
+
+var config = builder.Configuration;
 
 
 // Configura el logging
@@ -188,6 +191,25 @@ builder.Services.AddScoped<IProductCompartimentGetByCompartmentId, ProductCompar
 
 builder.Services.AddScoped<ICourtListDomainService, CourtListService>();
 builder.Services.AddScoped<IInventoryListDomainService, InventoryListService>();
+
+//Configura Tolgee
+
+builder.Services.AddScoped<ITolgeeService, TolgeeService>();
+
+builder.Services.AddHttpClient(nameof(TolgeeService), client =>
+{
+    var baseUrl = config["Tolgee:BaseUrl"];
+    if (string.IsNullOrWhiteSpace(baseUrl))
+        throw new InvalidOperationException("Tolgee:BaseUrl no está configurada.");
+
+    client.BaseAddress = new Uri(baseUrl);
+
+    var apiKey = config["Tolgee:ApiKey"];
+    if (!string.IsNullOrWhiteSpace(apiKey))
+        client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+});
+
+
 
 
 

--- a/Poliedro.Eds.Application/Translations/Handle/GetTranslationsHandler.cs
+++ b/Poliedro.Eds.Application/Translations/Handle/GetTranslationsHandler.cs
@@ -4,12 +4,16 @@ using Poliedro.Eds.Application.Ports.Translations;
 using Poliedro.Eds.Application.Translations.Dtos;
 using Poliedro.Eds.Application.Translations.Querys;
 
+
 namespace Poliedro.Eds.Application.Translations.Handle;
 
-public class GetTranslationsHandler(IRedisService redisService)
+public class GetTranslationsHandler(
+    IRedisService redisService,
+    ITolgeeService tolgeeService)
     : IRequestHandler<GetTranslationsQuery, TranslationsAvailableDto>
 {
     private const string RedisPrefix = "translations";
+
     private static readonly Dictionary<string, string> FlagToCountryCodeMap = new()
     {
         { "🇺🇸", "US" },
@@ -20,8 +24,19 @@ public class GetTranslationsHandler(IRedisService redisService)
         GetTranslationsQuery request,
         CancellationToken cancellationToken)
     {
-        
-        var translationKeys = await GetTranslationKeys();
+        var translationKeys = await redisService.GetKeysByPatternAsync($"{RedisPrefix}:*");
+
+        // Si no hay claves, buscar en Tolgee y cachear
+        if (translationKeys.Count == 0)
+        {
+            var tolgeeTranslations = await tolgeeService.GetAllTranslationsFromTolgee();
+
+            foreach (var (lang, dict) in tolgeeTranslations)
+                await redisService.SetCacheAsync($"{RedisPrefix}:{lang}", dict, TimeSpan.FromHours(24));
+
+            translationKeys = tolgeeTranslations.Keys.Select(lang => $"{RedisPrefix}:{lang}").ToList();
+        }
+
         var translationsByLanguage = new Dictionary<string, Dictionary<string, string>>();
         var languages = new List<Language>();
 
@@ -36,7 +51,6 @@ public class GetTranslationsHandler(IRedisService redisService)
 
             translationsByLanguage[langCode] = translations;
 
-         
             languages.Add(new Language
             {
                 Code = langCode,
@@ -53,32 +67,19 @@ public class GetTranslationsHandler(IRedisService redisService)
         );
     }
 
-    private async Task<List<string>> GetTranslationKeys()
+    private string GetLanguageName(string langCode) => langCode switch
     {
-        
-        
-         return await redisService.GetKeysByPatternAsync($"{RedisPrefix}:*");
-    }
+        "en" => "English",
+        "es-CO" => "Español (Colombia)",
+        _ => langCode
+    };
 
-    private string GetLanguageName(string langCode)
+    private string GetFlagEmoji(string langCode) => langCode switch
     {
-        return langCode switch
-        {
-            "en" => "English",
-            "es-CO" => "Español (Colombia)",
-            _ => langCode
-        };
-    }
-
-    private string GetFlagEmoji(string langCode)
-    {
-        return langCode switch
-        {
-            "en" => "🇺🇸",
-            "es-CO" => "🇨🇴",
-            _ => "🌐"
-        };
-    }
+        "en" => "🇺🇸",
+        "es-CO" => "🇨🇴",
+        _ => "🌐"
+    };
 
     private void MapCountryCodes(IEnumerable<Language> languages)
     {

--- a/Poliedro.Eds.Domain/Translations/DomainTranslations/ITolgeeService.cs
+++ b/Poliedro.Eds.Domain/Translations/DomainTranslations/ITolgeeService.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Poliedro.Eds.Application.Ports.Translations;
+
+public interface ITolgeeService
+{
+    Task<Dictionary<string, Dictionary<string, string>>> GetAllTranslationsFromTolgee();
+}

--- a/Poliedro.Tolgee/Translations/TolgeeService.cs
+++ b/Poliedro.Tolgee/Translations/TolgeeService.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Net.Http;
+using System.Text.Json;
+using Poliedro.Eds.Application.Ports.Translations;
+
+namespace Poliedro.Tolgee.Translations;
+
+public class TolgeeService(
+    ILogger<TolgeeService> logger,
+    IHttpClientFactory httpClientFactory) : ITolgeeService
+{
+    public async Task<Dictionary<string, Dictionary<string, string>>> GetAllTranslationsFromTolgee()
+    {
+        var httpClient = httpClientFactory.CreateClient(nameof(TolgeeService));
+        var response = await httpClient.GetAsync("translations?size=1000");
+
+        if (!response.IsSuccessStatusCode)
+            throw new Exception($"Error al consultar Tolgee: {response.StatusCode}");
+
+        var body = await response.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<RootObject>(body)
+                   ?? throw new Exception("Error deserializando respuesta de Tolgee");
+
+        var result = new Dictionary<string, Dictionary<string, string>>();
+
+        foreach (var key in data.translations.Keys)
+        {
+            foreach (var translation in key.Translations)
+            {
+                var lang = translation.Key;
+                var text = translation.Value.Text;
+
+                if (!result.TryGetValue(lang, out var dict))
+                {
+                    dict = new Dictionary<string, string>();
+                    result[lang] = dict;
+                }
+
+                dict[key.KeyName] = text;
+            }
+        }
+
+        return result;
+    }
+}

--- a/Poliedro.Tolgee/Translations/TranslationsService.cs
+++ b/Poliedro.Tolgee/Translations/TranslationsService.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
-using System.Text.Json;
 
 namespace Poliedro.Tolgee.Translations;
 
 public class TranslationCachingService(
     ILogger<TranslationCachingService> logger,
-    IHttpClientFactory httpClientFactory,
+    IServiceProvider serviceProvider,
     IRedisService redisService,
     IMemoryCache memoryCache) : IHostedService
 {
@@ -24,76 +24,53 @@ public class TranslationCachingService(
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        logger.LogInformation("Starting Translation Caching Service...");
+        logger.LogInformation("Iniciando servicio de cache de traducciones...");
+
+        using var scope = serviceProvider.CreateScope();
+        var tolgeeService = scope.ServiceProvider.GetRequiredService<ITolgeeService>();
+
         try
         {
             if (await IsCachePopulated())
             {
-                logger.LogInformation("Translations cache is already populated.");
+                logger.LogInformation("Cache ya poblada.");
                 return;
             }
 
-            var httpClient = httpClientFactory.CreateClient(nameof(TranslationCachingService));
-            var response = await httpClient.GetAsync("translations?size=1000");
+            var translationsByLanguage = await tolgeeService.GetAllTranslationsFromTolgee();
 
-            if (!response.IsSuccessStatusCode) throw new Exception($"Error fetching translations: {response.StatusCode}");
-            
-
-            var responseBody = await response.Content.ReadAsStringAsync();
-            var data = JsonSerializer.Deserialize<RootObject>(responseBody)
-                ?? throw new Exception("Error deserializing translations data");
-
-            var translationsByLanguage = new Dictionary<string, Dictionary<string, string>>();
-
-            foreach (var key in data.translations.Keys)
+            foreach (var (lang, translations) in translationsByLanguage)
             {
-                foreach (var translation in key.Translations)
-                {
-                    var language = translation.Key;
-                    var translationDetail = translation.Value;
-
-                    if (!translationsByLanguage.TryGetValue(language, out var langDict))
-                    {
-                        langDict = new Dictionary<string, string>();
-                        translationsByLanguage[language] = langDict;
-                    }
-
-                    langDict[key.KeyName] = translationDetail.Text;
-                }
-            }
-
-           
-            foreach (var (language, translations) in translationsByLanguage)
-            {
-                var cacheKey = GetCacheKey(language);
+                var cacheKey = GetCacheKey(lang);
                 await redisService.SetCacheAsync(cacheKey, translations, CacheExpiration);
                 memoryCache.Set(cacheKey, translations, _memoryCacheOptions);
-                logger.LogDebug("Cached translations for {Language}", language);
+                logger.LogDebug("Cacheado {lang}", lang);
             }
 
             await redisService.SetCacheAsync(CacheStatusKey, true, CacheExpiration);
-            logger.LogInformation("Translations cached for {LanguageCount} languages", translationsByLanguage.Count);
+            memoryCache.Set(CacheStatusKey, true, _memoryCacheOptions);
+            logger.LogInformation("Traducciones cacheadas.");
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error during translation caching: {Message}", ex.Message);
+            logger.LogError(ex, "Error cacheando traducciones");
         }
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        logger.LogInformation("Translation Caching Service stopping.");
+        logger.LogInformation("Deteniendo servicio de cache de traducciones.");
         return Task.CompletedTask;
     }
 
     public async Task<string?> GetTranslation(string language, string key)
     {
         var cacheKey = GetCacheKey(language);
+
         if (memoryCache.TryGetValue<Dictionary<string, string>>(cacheKey, out var memoryTranslations) &&
-            memoryTranslations != null &&
-            memoryTranslations.TryGetValue(key, out var memoryValue))
+            memoryTranslations.TryGetValue(key, out var value))
         {
-            return memoryValue;
+            return value;
         }
 
         var redisTranslations = await redisService.GetCacheAsync<Dictionary<string, string>>(cacheKey);
@@ -101,18 +78,19 @@ public class TranslationCachingService(
         {
             memoryCache.Set(cacheKey, redisTranslations, _memoryCacheOptions);
             return redisValue;
-        } 
-        logger.LogWarning("Translation not found: {Language}/{Key}", language, key);
+        }
+
+        logger.LogWarning("Traducción no encontrada: {Language}/{Key}", language, key);
         return null;
     }
 
     public async Task<Dictionary<string, string>?> GetAllTranslations(string language)
     {
         var cacheKey = GetCacheKey(language);
+
         if (memoryCache.TryGetValue<Dictionary<string, string>>(cacheKey, out var memoryTranslations))
-        {
             return memoryTranslations;
-        }
+
         var redisTranslations = await redisService.GetCacheAsync<Dictionary<string, string>>(cacheKey);
         if (redisTranslations != null)
         {
@@ -125,7 +103,9 @@ public class TranslationCachingService(
 
     private async Task<bool> IsCachePopulated()
     {
-        if (memoryCache.TryGetValue<bool>(CacheStatusKey, out var memoryStatus) && memoryStatus) return true;
+        if (memoryCache.TryGetValue(CacheStatusKey, out bool memoryStatus) && memoryStatus)
+            return true;
+
         var redisStatus = await redisService.GetCacheAsync<bool>(CacheStatusKey);
         if (redisStatus)
         {


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Add a TolgeeService to fetch translations from the Tolgee API and integrate it into the caching and query handlers, simplify the translation caching logic, register the service in dependency injection, and clean up related code.

New Features:
- Introduce ITolgeeService and its TolgeeService implementation to centralize translation fetching from Tolgee API
- Integrate TolgeeService into TranslationCachingService and GetTranslationsHandler for retrieving translations

Enhancements:
- Replace manual HTTP calls and JSON parsing in TranslationCachingService with calls to TolgeeService
- Simplify GetTranslationsHandler to fall back to Tolgee when the Redis cache is empty and cache the results
- Register TolgeeService and its HTTP client in the DI container and configure base URL and API key
- Clean up obsolete methods and consolidate language name and flag mapping logic
- Translate logging messages to Spanish and streamline cache population flow