### PR TITLE
correction  bug dispensers id

### DIFF
--- a/Poliedro.Eds.Api/Controllers/v1/DispenserType/DispenserType.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/DispenserType/DispenserType.cs
@@ -46,22 +46,15 @@ public class DispenserTypeController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpGet("{id}")]
-    public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetDispenserTypeByIdQuery> validator)
+
+    public async Task<IResult> GetById(int id)
     {
-        var getDispenserTypeQuery = new GetDispenserTypeByIdQuery(Id: id);
+        var result = await mediator.Send(new GetDispenserTypeByIdQuery(id));
 
-        //var validationResult = await validator.ValidateAsync(getDispenserTypeQuery);
+        if (result.IsSuccess)
+            return TypedResults.Ok(result.Value);
 
-        //if (!validationResult.IsValid)
-        //{
-        //    return TypedResults.BadRequest(validationResult.Errors);
-        //}
-
-        var result = await mediator.Send(getDispenserTypeQuery);
-
-        return result.Match(
-            onSuccess => TypedResults.Ok(result.Value)
-        );
+        return TypedResults.NotFound("DispenserType no encontrado.");
     }
 
     [SwaggerOperation(
@@ -98,11 +91,6 @@ public class DispenserTypeController(IMediator mediator) : ControllerBase
  [FromBody] UpdateDispenserTypeCommand updateDispenserTypeCommand,
  [FromServices] IValidator<UpdateDispenserTypeCommand> validator)
     {
-        //var validationResult = await validator.ValidateAsync(updateDispenserTypeCommand);
-        //if (!validationResult.IsValid)
-        //{
-        //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-        //}
 
         var result = await mediator.Send(updateDispenserTypeCommand);
 

--- a/Poliedro.Eds.Api/Controllers/v1/Dispensers/DipensersController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Dispensers/DipensersController.cs
@@ -10,6 +10,7 @@ using Poliedro.Eds.Application.Dispensers.Dtos;
 using Poliedro.Eds.Application.Dispensers.Errors;
 using Poliedro.Eds.Application.Dispensers.Queries.GellAllDispensers;
 using Poliedro.Eds.Application.Dispensers.Queries.GetDispensersById;
+using Poliedro.Eds.Application.DispenserType.Queries.GetDispenserTypeById;
 using Poliedro.Eds.Domain.Common.Pagination;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -46,22 +47,15 @@ public class DispensersController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpGet("{id}")]
-    public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetDispensersByIdQuery> validator)
+
+    public async Task<IResult> GetById(int id)
     {
-        var getDispenserseQuery = new GetDispensersByIdQuery(Id: id);
+        var result = await mediator.Send(new GetDispensersByIdQuery(id));
 
-        //var validationResult = await validator.ValidateAsync(getDispenserseQuery);
+        if (result.IsSuccess)
+            return TypedResults.Ok(result.Value);
 
-        //if (!validationResult.IsValid)
-        //{
-        //    return TypedResults.BadRequest(validationResult.Errors);
-        //}
-
-        var result = await mediator.Send(getDispenserseQuery);
-
-        return result.Match(
-            onSuccess => TypedResults.Ok(result.Value)
-        );
+        return TypedResults.NotFound("Dispenser no encontrado.");
     }
 
     [SwaggerOperation(


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Standardize and correct GetById endpoints in DispenserType and Dispensers controllers by removing unused validation code, simplifying mediator queries, and returning NotFound when an entity is missing.

Bug Fixes:
- Remove unused validator parameters and commented-out validation logic from both GetById endpoints.
- Refactor GetById methods to inline mediator.Send calls and return Ok on successful retrieval.
- Return TypedResults.NotFound with a localized message if the requested dispenser or dispenser type is not found.

Enhancements:
- Add missing namespace import for GetDispenserTypeByIdQuery in Dispensers controller.