### PR TITLE
logic correction

### DIFF
--- a/Poliedro.Eds.Domain/Product/Entities/ProductEntity.cs
+++ b/Poliedro.Eds.Domain/Product/Entities/ProductEntity.cs
@@ -9,5 +9,4 @@ public class ProductEntity
     public string Name { get; set; } = default!;
     public int IdProductType { get; set; }
     public double Price { get; set; }
-    public DateTime Date { get; set; }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/ProductConfiguration.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/ProductConfiguration.cs
@@ -15,9 +15,5 @@ public class ProductConfiguration
         builder.Property(x => x.IdProductType).HasColumnName("id_product_type");
         builder.Property(x => x.Price).HasColumnName("price");
 
-        builder.Property(x => x.Date)
-           .HasColumnName("date")
-           .ValueGeneratedOnAdd();
-
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
@@ -31,9 +31,6 @@ public class HoseGetAllHose(
                     join productType in context.ProductTypes on hose.IdProductType equals productType.IdProductType
                     join eds in context.Eds on dispenser.EdsId equals eds.IdEds
                     join product in context.Product on hose.IdProductType equals product.IdProductType
-                    where product.Date == context.Product
-                    .Where(p => p.IdProductType == hose.IdProductType)
-                    .Max(p => p.Date)
 
                     select new HoseDto(
                         hose.IdHose,


### PR DESCRIPTION
### Checklist antes de hacer merge

- [x] Code compiles correctly  
- [x] Tests have been added  
- [x] Documentation has been updated  
- [x] Team has been informed about the changes

## Summary by Sourcery

Remove the Date property from ProductEntity and its EF mapping, and correct the hose retrieval logic by eliminating the outdated date-based filter.

Enhancements:
- Drop Date field from ProductEntity and its database configuration
- Remove date comparison clause from HoseGetAllHose query logic