### PR TITLE
Feature/clear cache prefixes

### DIFF
--- a/Poliedro.Eds.Application/Ports/Redis/IRedisService.cs
+++ b/Poliedro.Eds.Application/Ports/Redis/IRedisService.cs
@@ -8,6 +8,7 @@ public interface IRedisService
     Task<T?> GetCacheAsync<T>(string key);
     Task<bool> RemoveCacheAsync(string key);
     Task RemoveByPrefixAsync(string prefix);
+    Task RemoveByPrefixesAsync(IEnumerable<string> prefixes);
     Task<List<string>> GetKeysByPatternAsync(string pattern);
     Task<string?> GetValueFromCacheAsync(string key);
 }

--- a/Poliedro.Eds.Application/Ports/Redis/IRedisService.cs
+++ b/Poliedro.Eds.Application/Ports/Redis/IRedisService.cs
@@ -8,7 +8,7 @@ public interface IRedisService
     Task<T?> GetCacheAsync<T>(string key);
     Task<bool> RemoveCacheAsync(string key);
     Task RemoveByPrefixAsync(string prefix);
-    Task RemoveByPrefixesAsync(IEnumerable<string> prefixes);
+    Task RemoveByPrefixAsync(IEnumerable<string> prefixes);
     Task<List<string>> GetKeysByPatternAsync(string pattern);
     Task<string?> GetValueFromCacheAsync(string key);
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Court/Repositories/CourtCreateService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Court/Repositories/CourtCreateService.cs
@@ -17,11 +17,11 @@ public class CourtCreateService(ITenantDbContextFactory dbContextFactory, IRedis
         var result = await context.SaveChangesAsync() > 0;
         if (!result)
             return CourtErrorBuilder.CourtCreationException();
-        await redisService.RemoveByPrefixesAsync(new[]
+        await redisService.RemoveByPrefixAsync(new[]
         {
             "business:",
             "compartiment:",
-            "dispenser:",
+            "dispensers:",
             "eds:",
             "expenditures:",
             "hose:",

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Court/Repositories/CourtCreateService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Court/Repositories/CourtCreateService.cs
@@ -17,7 +17,20 @@ public class CourtCreateService(ITenantDbContextFactory dbContextFactory, IRedis
         var result = await context.SaveChangesAsync() > 0;
         if (!result)
             return CourtErrorBuilder.CourtCreationException();
-        await redisService.RemoveByPrefixAsync("courtListService:");
+        await redisService.RemoveByPrefixesAsync(new[]
+        {
+            "business:",
+            "compartiment:",
+            "dispenser:",
+            "eds:",
+            "expenditures:",
+            "hose:",
+            "islander:",
+            "product:",
+            "translations:",
+            "typeOfCollection:"
+        }
+        );
         return VoidResult.Instance;
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Redis/RedisCacheService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Redis/RedisCacheService.cs
@@ -108,12 +108,10 @@ public class RedisCacheService : IRedisService
         }
     }
 
-    public async Task RemoveByPrefixesAsync(IEnumerable<string> prefixes)
+    public async Task RemoveByPrefixAsync(IEnumerable<string> prefixes)
     {
-        foreach (var prefix in prefixes)
-        {
-            await RemoveByPrefixAsync(prefix);
-        }
+        var tasks = prefixes.Select(prefix => RemoveByPrefixAsync(prefix));
+        await Task.WhenAll(tasks);
     }
 
     public async Task<List<string>> GetKeysByPatternAsync(string pattern)

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Redis/RedisCacheService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Redis/RedisCacheService.cs
@@ -107,6 +107,15 @@ public class RedisCacheService : IRedisService
             Console.WriteLine($"[Error] removing cache keys by prefix '{prefix}': {ex.Message}");
         }
     }
+
+    public async Task RemoveByPrefixesAsync(IEnumerable<string> prefixes)
+    {
+        foreach (var prefix in prefixes)
+        {
+            await RemoveByPrefixAsync(prefix);
+        }
+    }
+
     public async Task<List<string>> GetKeysByPatternAsync(string pattern)
     {
         try


### PR DESCRIPTION
### Checklist antes de hacer merge

- [x] Code compiles correctly  
- [x] Tests have been added  
- [x] Documentation has been updated  
- [x] Team has been informed about the changes

## Summary by Sourcery

Support removal of multiple cache prefixes and apply it to clear various cache segments in CourtCreateService following a new court creation

New Features:
- Add RemoveByPrefixAsync overload to accept multiple prefix values

Enhancements:
- Invoke batch cache prefix removal in CourtCreateService to invalidate related cache entries after creating a court