### PR TITLE
Hu 1183 validator tolgee

### DIFF
--- a/Poliedro.Eds.Application/Business/Commands/UpdateBusiness/UpdateBusinessCommandValidator.cs
+++ b/Poliedro.Eds.Application/Business/Commands/UpdateBusiness/UpdateBusinessCommandValidator.cs
@@ -1,18 +1,19 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Business.Commands.UpdateBusiness;
 
 public class UpdateBusinessCommandValidator : AbstractValidator<UpdateBusinessCommand>
 {
-    //public UpdateBusinessCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.IdBusiness).NotNull().GreaterThan(0) 
-    //         .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdBusinessGreaterThan").GetAwaiter().GetResult());
+    public UpdateBusinessCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdBusiness).NotNull().GreaterThan(0)
+             .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdBusinessGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Name)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Name)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult());
 
-    //}
+    }
 }

--- a/Poliedro.Eds.Application/Business/Queries/GetBusinessById/GetBusinessByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Business/Queries/GetBusinessById/GetBusinessByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Business.Queries.GetBusinessById;
 
 public class GetBusinessIdQueryValidator : AbstractValidator<GetBusinessByIdQuery>
 {
-    //public GetBusinessIdQueryValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Id)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-    //}
+    public GetBusinessIdQueryValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+    }
 }
 

--- a/Poliedro.Eds.Application/Capacity/Commands/CreateCapacity/CreateCapacityCommandValidator.cs
+++ b/Poliedro.Eds.Application/Capacity/Commands/CreateCapacity/CreateCapacityCommandValidator.cs
@@ -1,37 +1,38 @@
 ﻿using FluentValidation;
 using Poliedro.Eds.Application.Capacity.Queries.GetCapacityById;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Capacity.Commands.CreateCapacity;
 
 public class CreateCapacityCommandValidator : AbstractValidator<CreateCapacityRequestDto>
 {
-    //public CreateCapacityCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Code)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("CodeNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("CodeNotEmpty").GetAwaiter().GetResult())
-    //        .NotEqual("string").WithMessage(translationService.GetTranslationByKey("CodeNotEqual").GetAwaiter().GetResult()); 
+    public CreateCapacityCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Code)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("CodeNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("CodeNotEmpty").GetAwaiter().GetResult())
+            .NotEqual("string").WithMessage(redisService.GetValueFromCacheAsync("CodeNotEqual").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Height)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("HeightNotNull").GetAwaiter().GetResult())    
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("HeightNotEmpty").GetAwaiter().GetResult()); 
+        RuleFor(x => x.Height)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("HeightNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("HeightNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Gallon)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("GallonNotNull").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("GallonNotEmpty").GetAwaiter().GetResult()); 
+        RuleFor(x => x.Gallon)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("GallonNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("GallonNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Liters)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("LitersNotNull").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("LitersNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Liters)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("LitersNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("LitersNotEmpty").GetAwaiter().GetResult());
 
-    //}
-    //public class GetCapacityByIdCommandValidator : AbstractValidator<GetCapacityByIdQuery>
-    //{
-    //    public GetCapacityByIdCommandValidator(ITranslationService translationService)
-    //    {
-    //        RuleFor(x => x.Id)
-    //            .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-    //    }
-    //}
+    }
+    public class GetCapacityByIdCommandValidator : AbstractValidator<GetCapacityByIdQuery>
+    {
+        public GetCapacityByIdCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
+    }
 }

--- a/Poliedro.Eds.Application/Capacity/Commands/UpdateCapacity/UpdateCapacityCommandValidator.cs
+++ b/Poliedro.Eds.Application/Capacity/Commands/UpdateCapacity/UpdateCapacityCommandValidator.cs
@@ -1,30 +1,31 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Capacity.Commands.UpdateCapacity;
 
 public class UpdateCapacityCommandValidator : AbstractValidator<UpdateCapacityCommand>
 {
-    //public UpdateCapacityCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.IdCapacity).NotNull().GreaterThan(0)
-    //         .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdCapacityGreaterThan").GetAwaiter().GetResult());
+    public UpdateCapacityCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdCapacity).NotNull().GreaterThan(0)
+             .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdCapacityGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Code)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("CodeNotNull").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("CodeNotEmpty").GetAwaiter().GetResult()); 
+        RuleFor(x => x.Code)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("CodeNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("CodeNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Height)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("HeightNotNull").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("HeightNotEmpty").GetAwaiter().GetResult()); 
+        RuleFor(x => x.Height)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("HeightNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("HeightNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Gallon)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("GallonNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("GallonNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Gallon)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("GallonNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("GallonNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Liters)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("LitersNotNull").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("LitersNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Liters)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("LitersNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("LitersNotEmpty").GetAwaiter().GetResult());
 
-    //}
+    }
 }

--- a/Poliedro.Eds.Application/Capacity/Queries/GetCapacityById/GetCapacityByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Capacity/Queries/GetCapacityById/GetCapacityByIdQueryValidator.cs
@@ -1,13 +1,14 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Capacity.Queries.GetCapacityById;
 public class GetCapacityIdQueryValidator : AbstractValidator<GetCapacityByIdQuery>
 {
-    //public GetCapacityIdQueryValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Id)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("GreaterThan").GetAwaiter().GetResult());
-    //}
+    public GetCapacityIdQueryValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("GreaterThan").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/Category/Commands/CreateCategory/CreateCategoryCommandValidator.cs
+++ b/Poliedro.Eds.Application/Category/Commands/CreateCategory/CreateCategoryCommandValidator.cs
@@ -1,16 +1,17 @@
 ﻿using FluentValidation;
 using Poliedro.Eds.Application.Category.Commands.CreateCategory;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Category.CreateCategory;
 
 public class CreateCategoryCommandValidator : AbstractValidator<CreateCategoryRequestDto>
 {
-    //public CreateCategoryCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Description)
-    //       .NotEmpty().WithMessage(translationService.GetTranslationByKey("DescriptionNotEmpty").GetAwaiter().GetResult()) 
-    //       .MaximumLength(45).WithMessage(translationService.GetTranslationByKey("DescriptionMaximumLength").GetAwaiter().GetResult()) 
-    //       .Matches(@"^[a-zA-Z0-9\s]+$").WithMessage(translationService.GetTranslationByKey("DescriptionMatches").GetAwaiter().GetResult());
-    //}
+    public CreateCategoryCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Description)
+           .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotEmpty").GetAwaiter().GetResult())
+           .MaximumLength(45).WithMessage(redisService.GetValueFromCacheAsync("DescriptionMaximumLength").GetAwaiter().GetResult())
+           .Matches(@"^[a-zA-Z0-9\s]+$").WithMessage(redisService.GetValueFromCacheAsync("DescriptionMatches").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/Category/Commands/UpdateCategory/UpdateCategoryCommandValidator.cs
+++ b/Poliedro.Eds.Application/Category/Commands/UpdateCategory/UpdateCategoryCommandValidator.cs
@@ -1,18 +1,19 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 namespace Poliedro.Eds.Application.Category.Commands.UpdateCategory;
     public class UpdateCategoryCommandValidator : AbstractValidator<UpdateCategoryCommand>
     {
-    //    public UpdateCategoryCommandValidator(ITranslationService translationService)
-    //    {
-    //    RuleFor(x => x.IdCategory)
-    //    .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdCategoryGreaterThan").GetAwaiter().GetResult())
-    //    .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdCategoryNotEmpty").GetAwaiter().GetResult()); 
+    public UpdateCategoryCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdCategory)
+        .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdCategoryGreaterThan").GetAwaiter().GetResult())
+        .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdCategoryNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Description)
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DescriptionNotEmpty").GetAwaiter().GetResult()) 
-    //        .MaximumLength(45).WithMessage(translationService.GetTranslationByKey("DescriptionMaximumLength").GetAwaiter().GetResult()) 
-    //        .Matches(@"^[a-zA-Z0-9\s]+$").WithMessage(translationService.GetTranslationByKey("DescriptionMatches").GetAwaiter().GetResult()); 
-    //}
+        RuleFor(x => x.Description)
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotEmpty").GetAwaiter().GetResult())
+            .MaximumLength(45).WithMessage(redisService.GetValueFromCacheAsync("DescriptionMaximumLength").GetAwaiter().GetResult())
+            .Matches(@"^[a-zA-Z0-9\s]+$").WithMessage(redisService.GetValueFromCacheAsync("DescriptionMatches").GetAwaiter().GetResult());
     }
+}
 

--- a/Poliedro.Eds.Application/Category/Queries/GetCategoryById/GetCategoryByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Category/Queries/GetCategoryById/GetCategoryByIdQueryValidator.cs
@@ -1,14 +1,15 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Category.Queries.GetCategoryById;
 
     public class GetCategoryByIdQueryValidator : AbstractValidator<GetCategoryByIdQuery>
     {
-        //public GetCategoryByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult()); 
-        //}
+    public GetCategoryByIdQueryValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
     }
+}

--- a/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentCommandValidator.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Poliedro.Eds.Application.Compartiment.Commands.CreateCompartiment;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 
@@ -7,26 +8,26 @@ namespace Poliedro.Eds.Application.Compartiment.CreateCompartiment;
 
 public class CreateCompartimentCommandValidator : AbstractValidator<CreateCompartimentRequestDto>
 {
-    //public CreateCompartimentCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Number)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("NumberGreaterThan").GetAwaiter().GetResult()); 
+    public CreateCompartimentCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Number)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("NumberGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Nominal)
-    //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("NominalGreaterThanOrEqualTo").GetAwaiter().GetResult()); 
+        RuleFor(x => x.Nominal)
+            .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("NominalGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Operative)
-    //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult()) 
-    //        .LessThanOrEqualTo(x => x.Stock).WithMessage(translationService.GetTranslationByKey("OperativeLessThanOrEqualTo").GetAwaiter().GetResult()); 
+        RuleFor(x => x.Operative)
+            .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult())
+            .LessThanOrEqualTo(x => x.Stock).WithMessage(redisService.GetValueFromCacheAsync("OperativeLessThanOrEqualTo").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Stock)
-    //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("StockGreaterThanOrEqualTo").GetAwaiter().GetResult()); 
+        RuleFor(x => x.Stock)
+            .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("StockGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Height)
-    //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("HeightGreaterThanOrEqualTo").GetAwaiter().GetResult()); 
+        RuleFor(x => x.Height)
+            .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("HeightGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdTank)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdTankGreaterThan").GetAwaiter().GetResult()); 
-    //}
+        RuleFor(x => x.IdTank)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdTankGreaterThan").GetAwaiter().GetResult());
+    }
 
 }

--- a/Poliedro.Eds.Application/Compartiment/Commands/UpdateServer/UpdateCompartimentCommandValidator.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/UpdateServer/UpdateCompartimentCommandValidator.cs
@@ -1,35 +1,36 @@
 ﻿using FluentValidation;
 using Microsoft.AspNetCore.JsonPatch.Operations;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 using static System.Runtime.InteropServices.JavaScript.JSType;
 namespace Poliedro.Eds.Application.Compartiment.Commands.UpdateCompartiment
 {
     public class UpdateCompartimentCommandValidator : AbstractValidator<UpdateCompartimentCommand>
     {
-        //public UpdateCompartimentCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.IdCompartment)
-        //   .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdCompartmentGreaterThan").GetAwaiter().GetResult())
-        //   .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdCompartmentNotEmpty").GetAwaiter().GetResult()); 
+        public UpdateCompartimentCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.IdCompartment)
+           .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdCompartmentGreaterThan").GetAwaiter().GetResult())
+           .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdCompartmentNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Number)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("NumberGreaterThan").GetAwaiter().GetResult()); 
+            RuleFor(x => x.Number)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("NumberGreaterThan").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Nominal)
-        //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("NominalGreaterThanOrEqualTo").GetAwaiter().GetResult());
-        //    RuleFor(x => x.Operative)
-        //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult()) 
-        //        .LessThanOrEqualTo(x => x.Stock).WithMessage(translationService.GetTranslationByKey("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult());
+            RuleFor(x => x.Nominal)
+                .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("NominalGreaterThanOrEqualTo").GetAwaiter().GetResult());
+            RuleFor(x => x.Operative)
+                .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult())
+                .LessThanOrEqualTo(x => x.Stock).WithMessage(redisService.GetValueFromCacheAsync("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Stock)
-        //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("StockGreaterThanOrEqualTo").GetAwaiter().GetResult());
+            RuleFor(x => x.Stock)
+                .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("StockGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Height)
-        //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("HeightGreaterThanOrEqualTo").GetAwaiter().GetResult());
+            RuleFor(x => x.Height)
+                .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("HeightGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdTank)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdTankGreaterThan").GetAwaiter().GetResult())  
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdTankNotEmpty").GetAwaiter().GetResult()); 
-        //}
+            RuleFor(x => x.IdTank)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdTankGreaterThan").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdTankNotEmpty").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Compartiment/Queries/GetDispensersById/GetCompartimentByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Compartiment/Queries/GetDispensersById/GetCompartimentByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Compartiment.Queries.GetCompartimentById
 {
     public class GetCompartimentByIdQueryValidator : AbstractValidator<GetCompartimentByIdQuery>
     {
-        //public GetCompartimentByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult()); 
-        //}
+        public GetCompartimentByIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/CompartimentCapacity/Commands/CreateCompartimentCapacity/CreateCompartimentCapacityCommandValidator.cs
+++ b/Poliedro.Eds.Application/CompartimentCapacity/Commands/CreateCompartimentCapacity/CreateCompartimentCapacityCommandValidator.cs
@@ -1,25 +1,26 @@
 ﻿using FluentValidation;
 using Poliedro.Eds.Application.Court.Commands.CreateCourt;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.CompartimentCapacity.Commands.CreateCompartimentCapacity;
 
 public class CreateCompartimentCapacityCommandValidator : AbstractValidator<CreateCompartimentCapacityRequestDto>
 {
-    //public CreateCompartimentCapacityCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.IdCompartiment)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdCompartimentNotNull").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdCompartimentNotEmpty").GetAwaiter().GetResult());
+    public CreateCompartimentCapacityCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdCompartiment)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdCompartimentNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdCompartimentNotEmpty").GetAwaiter().GetResult());
 
 
-    //    RuleFor(x => x.IdCapacity)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdCapacityNotNull").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdCapacityNotEmpty").GetAwaiter().GetResult()); 
+        RuleFor(x => x.IdCapacity)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdCapacityNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdCapacityNotEmpty").GetAwaiter().GetResult());
 
 
-    //    RuleFor(x => x.Default)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("DefaultNotNull").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DefaultNotEmpty").GetAwaiter().GetResult()); 
-    //}
+        RuleFor(x => x.Default)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DefaultNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DefaultNotEmpty").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/CompartimentCapacity/Commands/UpdateCompartimentCapacity/UpdateCompartimentCapacityCommandValidator.cs
+++ b/Poliedro.Eds.Application/CompartimentCapacity/Commands/UpdateCompartimentCapacity/UpdateCompartimentCapacityCommandValidator.cs
@@ -1,22 +1,23 @@
 ﻿using FluentValidation;
 using Poliedro.Eds.Application.Court.Commands.CreateCourt;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.CompartimentCapacity.Commands.UpdateCompartimentCapacity;
     public class UpdateCompartimentCapacityCommandValidator : AbstractValidator<UpdateCompartimentCapacityCommand>
     {
-    //    public UpdateCompartimentCapacityCommandValidator(ITranslationService translationService)
-    //{
-    //        RuleFor(x => x.IdCompartiment)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("IdCompartimentNotNull").GetAwaiter().GetResult()) 
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdCompartimentNotEmpty").GetAwaiter().GetResult()); 
+    public UpdateCompartimentCapacityCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdCompartiment)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdCompartimentNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdCompartimentNotEmpty").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.IdCapacity)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("IdCapacityNotNull").GetAwaiter().GetResult()) 
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdCapacityNotEmpty").GetAwaiter().GetResult()); 
+        RuleFor(x => x.IdCapacity)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdCapacityNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdCapacityNotEmpty").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.Default)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("DefaultNotNull").GetAwaiter().GetResult()) 
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("DefaultNotEmpty").GetAwaiter().GetResult());
-    //    }
+        RuleFor(x => x.Default)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DefaultNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DefaultNotEmpty").GetAwaiter().GetResult());
     }
+}

--- a/Poliedro.Eds.Application/CompartimentCapacity/Queries/GetCompartimentCapacityById/GetCompartimentCapacityByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/CompartimentCapacity/Queries/GetCompartimentCapacityById/GetCompartimentCapacityByIdQueryValidator.cs
@@ -1,13 +1,14 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.CompartimentCapacity.Queries.GetCompartimentCapacityById;
     public class GetCompartimentCapacityByIdQueryValidator : AbstractValidator<GetCompartimentCapacityByIdQuery>
     {
-        //public GetCompartimentCapacityByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+    public GetCompartimentCapacityByIdQueryValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
     }
+}

--- a/Poliedro.Eds.Application/Court/Commands/UpdateCourt/UpdateCourtCommandValidator.cs
+++ b/Poliedro.Eds.Application/Court/Commands/UpdateCourt/UpdateCourtCommandValidator.cs
@@ -1,40 +1,41 @@
 ﻿using FluentValidation;
 using Poliedro.Eds.Application.Court.Commands.CreateCourt;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Court.Commands.UpdateCourt
 {
     public class UpdateCourtCommandValidator : AbstractValidator<UpdateCourtCommand>
     {
-    //    public UpdateCourtCommandValidator(ITranslationService translationService)
-    //    {
-    //        RuleFor(x => x.IdCourt)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("IdCourtNotNull").GetAwaiter().GetResult())
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdCourtNotEmpty").GetAwaiter().GetResult()); 
+        public UpdateCourtCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.IdCourt)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdCourtNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdCourtNotEmpty").GetAwaiter().GetResult()); 
 
-    //        RuleFor(x => x.DateStarttime)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("DateStrattimeNotNull").GetAwaiter().GetResult()) 
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("DateNotEmpty").GetAwaiter().GetResult());
+            RuleFor(x => x.DateStarttime)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DateStrattimeNotNull").GetAwaiter().GetResult()) 
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DateNotEmpty").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.Starttime)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("StarttimeNotNull").GetAwaiter().GetResult()) 
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("StarttimeNotEmpty").GetAwaiter().GetResult());
+            RuleFor(x => x.Starttime)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("StarttimeNotNull").GetAwaiter().GetResult()) 
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("StarttimeNotEmpty").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.DateEndtime)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("DateEndtimeNotNull").GetAwaiter().GetResult())
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("DateNotEmpty").GetAwaiter().GetResult());
+            RuleFor(x => x.DateEndtime)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DateEndtimeNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DateNotEmpty").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.Endtime)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("EndtimeNotNull").GetAwaiter().GetResult()) 
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("EndtimeNotEmpty").GetAwaiter().GetResult());
-    //    }
-    //    public class GetServerByIdCommandValidator : AbstractValidator<GetCourtByIdCommand>
-    //    {
-    //        public GetServerByIdCommandValidator(ITranslationService translationService)
-    //        {
-    //            RuleFor(x => x.Id)
-    //                .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult()); 
-    //        }
-    //    }
+            RuleFor(x => x.Endtime)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("EndtimeNotNull").GetAwaiter().GetResult()) 
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("EndtimeNotEmpty").GetAwaiter().GetResult());
+        }
+        public class GetServerByIdCommandValidator : AbstractValidator<GetCourtByIdCommand>
+        {
+            public GetServerByIdCommandValidator(IRedisService redisService)
+            {
+                RuleFor(x => x.Id)
+                    .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult()); 
+            }
+        }
     }
 }

--- a/Poliedro.Eds.Application/Court/Queris/GetCourtById/GetCourtByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Court/Queris/GetCourtById/GetCourtByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Court.Queris.GetCourtById
 {
     public class GetCourtByIdQueryValidator : AbstractValidator<GetCourtByIdQuery>
     {
-        //public GetCourtByIdQueryValidator(ITranslationService translationService)
-        //{
-        //     RuleFor(x => x.Id)
-        //    .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult()) 
-        //    .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetCourtByIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+           .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+           .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/CourtDispensersInventory/Commands/CreateCourtDispensersInventory/CreateCourtDispensersInventoryCommandValidator.cs
+++ b/Poliedro.Eds.Application/CourtDispensersInventory/Commands/CreateCourtDispensersInventory/CreateCourtDispensersInventoryCommandValidator.cs
@@ -1,18 +1,19 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.CourtDispensersInventory.Commands.CreateCourtDispensersInventory;
 
 public class CreateCourtDispensersInventoryCommandValidator : AbstractValidator<CreateCourtDispensersInventoryRequestDto>
 {
-    //public CreateCourtDispensersInventoryCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.IdCourtdDispensers)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdCourtdDispensersNotNul").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdCourtdDispensersNotNul").GetAwaiter().GetResult()); 
+    public CreateCourtDispensersInventoryCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdCourtdDispensers)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdCourtdDispensersNotNul").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdCourtdDispensersNotNul").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdInventory)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdInventoryNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdInventoryGreaterThan").GetAwaiter().GetResult());
-    //}
+        RuleFor(x => x.IdInventory)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdInventoryNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdInventoryGreaterThan").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/CourtDispensersInventory/Commands/UpdateCourtDispensersInventory/UpdateCourtDispensersInventoryCommandValidator.cs
+++ b/Poliedro.Eds.Application/CourtDispensersInventory/Commands/UpdateCourtDispensersInventory/UpdateCourtDispensersInventoryCommandValidator.cs
@@ -1,19 +1,20 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.CourtDispensersInventory.Commands.UpdateCourtDispensersInventory
 {
     public class UpdateCourtDispensersInventoryCommandValidator : AbstractValidator<UpdateCourtDispensersInventoryCommand>
     {
-        //public UpdateCourtDispensersInventoryCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.IdCourtdDispensers)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdCourtdDispensersNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdCourtdDispensersGreaterThan").GetAwaiter().GetResult());
+        public UpdateCourtDispensersInventoryCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.IdCourtdDispensers)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdCourtdDispensersNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdCourtdDispensersGreaterThan").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdInventory)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdInventoryNotNull").GetAwaiter().GetResult()) 
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdInventoryGreaterThan").GetAwaiter().GetResult()); 
-        //}
+            RuleFor(x => x.IdInventory)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdInventoryNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdInventoryGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/CourtDispensersInventory/Queries/GetCourtDispensersInventoryById/GetCourtDispensersInventoryByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/CourtDispensersInventory/Queries/GetCourtDispensersInventoryById/GetCourtDispensersInventoryByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.CourtDispensersInventory.Queries.GetCourtDispensersInventoryById
 {
     public class GetCourtDispensersInventoryIdQueryValidator : AbstractValidator<GetCourtDispensersInventoryByIdQuery>
     {
-        //public GetCourtDispensersInventoryIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetCourtDispensersInventoryIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/DispenserType/Commands/CreateServer/CreateDispenserTypeCommandValidator.cs
+++ b/Poliedro.Eds.Application/DispenserType/Commands/CreateServer/CreateDispenserTypeCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Poliedro.Eds.Application.DispenserType.Commands.CreateDispenserType;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 
@@ -7,10 +8,10 @@ namespace Poliedro.Eds.Application.Server.DispenserType.CreateDispenserType;
 
 public class CreateDispenserTypeCommandValidator : AbstractValidator<CreateDispenserTypeRequestDto>
 {
-    //public CreateDispenserTypeCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Description)
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DescriptionNotEmpty").GetAwaiter().GetResult())
-    //        .MaximumLength(50).WithMessage(translationService.GetTranslationByKey("DescriptionMaximumLength").GetAwaiter().GetResult());
-    //}
+    public CreateDispenserTypeCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Description)
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotEmpty").GetAwaiter().GetResult())
+            .MaximumLength(50).WithMessage(redisService.GetValueFromCacheAsync("DescriptionMaximumLength").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/DispenserType/Commands/UpdateServer/UpdateDispenserTypeCommandValidator.cs
+++ b/Poliedro.Eds.Application/DispenserType/Commands/UpdateServer/UpdateDispenserTypeCommandValidator.cs
@@ -1,18 +1,19 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 namespace Poliedro.Eds.Application.DispenserType.Commands.UpdateDispenserType
 {
     public class UpdateDispenserTypeCommandValidator : AbstractValidator<UpdateDispenserTypeCommand>
     {
-    //    public UpdateDispenserTypeCommandValidator(ITranslationService translationService)
-    //    {
-    //        RuleFor(x => x.IdType) 
-    //.NotNull().WithMessage(translationService.GetTranslationByKey("IdTypeNotNull").GetAwaiter().GetResult()) // Asegura que no sea null
-    //.GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdTypeGreaterThan").GetAwaiter().GetResult()); // Debe ser mayor que 0
+        public UpdateDispenserTypeCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.IdType)
+    .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdTypeNotNull").GetAwaiter().GetResult()) // Asegura que no sea null
+    .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdTypeGreaterThan").GetAwaiter().GetResult()); // Debe ser mayor que 0
 
-    //        RuleFor(x => x.Description) 
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("DescriptionNotEmpty").GetAwaiter().GetResult()) 
-    //            .MaximumLength(50).WithMessage(translationService.GetTranslationByKey("DescriptionMaximumLength").GetAwaiter().GetResult()); 
-    //    }
+            RuleFor(x => x.Description)
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotEmpty").GetAwaiter().GetResult())
+                .MaximumLength(50).WithMessage(redisService.GetValueFromCacheAsync("DescriptionMaximumLength").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/DispenserType/Queries/GetDispensersById/GetDispenserTypeByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/DispenserType/Queries/GetDispensersById/GetDispenserTypeByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.DispenserType.Queries.GetDispenserTypeById
 {
     public class GetDispenserTypeByIdQueryValidator : AbstractValidator<GetDispenserTypeByIdQuery>
     {
-        //public GetDispenserTypeByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetDispenserTypeByIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Dispensers/Commands/CreateServer/CreateDispensersCommandValidator.cs
+++ b/Poliedro.Eds.Application/Dispensers/Commands/CreateServer/CreateDispensersCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Poliedro.Eds.Application.Dispensers.Commands.CreateDispensers;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 
@@ -7,27 +8,27 @@ namespace Poliedro.Eds.Application.Dispensers.Dispensers.CreateDispensers;
 
 public class CreateDispensersCommandValidator : AbstractValidator<CreateDispensersRequestDto>
 {
-    //public CreateDispensersCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Code)
-    //.NotEmpty().WithMessage(translationService.GetTranslationByKey("CodeNotEmpty").GetAwaiter().GetResult()) 
-    //.MaximumLength(50).WithMessage(translationService.GetTranslationByKey("CodeMaximumLength").GetAwaiter().GetResult()); 
+    public CreateDispensersCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Code)
+    .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("CodeNotEmpty").GetAwaiter().GetResult())
+    .MaximumLength(50).WithMessage(redisService.GetValueFromCacheAsync("CodeMaximumLength").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Number)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("NumberGreaterThan").GetAwaiter().GetResult()); 
+        RuleFor(x => x.Number)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("NumberGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.DispenserTypeId)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("DispenserTypeIdGreaterThan").GetAwaiter().GetResult()); 
+        RuleFor(x => x.DispenserTypeId)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("DispenserTypeIdGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.HoseNumber)
-    //        .GreaterThanOrEqualTo(1).WithMessage(translationService.GetTranslationByKey("HoseNumberGreaterThanOrEqualTo").GetAwaiter().GetResult()); 
+        RuleFor(x => x.HoseNumber)
+            .GreaterThanOrEqualTo(1).WithMessage(redisService.GetValueFromCacheAsync("HoseNumberGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.EdsId)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("EdsIdGreaterThan").GetAwaiter().GetResult()); 
+        RuleFor(x => x.EdsId)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("EdsIdGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdIsland)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdIslandGreaterThan").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdIslandNotEmpty").GetAwaiter().GetResult());  
-    //}
+        RuleFor(x => x.IdIsland)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdIslandGreaterThan").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdIslandNotEmpty").GetAwaiter().GetResult());
+    }
 
 }

--- a/Poliedro.Eds.Application/Dispensers/Commands/UpdateServer/UpdateDispensersCommandValidator.cs
+++ b/Poliedro.Eds.Application/Dispensers/Commands/UpdateServer/UpdateDispensersCommandValidator.cs
@@ -1,34 +1,35 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 namespace Poliedro.Eds.Application.Dispensers.Commands.UpdateDispensers
 {
     public class UpdateDispensersCommandValidator : AbstractValidator<UpdateDispensersCommand>
     {
-        //public UpdateDispensersCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdNotEmpty").GetAwaiter().GetResult()); 
+        public UpdateDispensersCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Code)
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("CodeNotEmpty").GetAwaiter().GetResult())
-        //        .MaximumLength(50).WithMessage(translationService.GetTranslationByKey("CodeMaximumLength").GetAwaiter().GetResult());
+            RuleFor(x => x.Code)
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("CodeNotEmpty").GetAwaiter().GetResult())
+                .MaximumLength(50).WithMessage(redisService.GetValueFromCacheAsync("CodeMaximumLength").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Number)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("NumberGreaterThan").GetAwaiter().GetResult());
+            RuleFor(x => x.Number)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("NumberGreaterThan").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.DispenserTypeId) 
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("DispenserTypeIdGreaterThan").GetAwaiter().GetResult());
+            RuleFor(x => x.DispenserTypeId)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("DispenserTypeIdGreaterThan").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.HoseNumber)
-        //        .GreaterThanOrEqualTo(1).WithMessage(translationService.GetTranslationByKey("HoseNumberGreaterThanOrEqualTo").GetAwaiter().GetResult()); 
+            RuleFor(x => x.HoseNumber)
+                .GreaterThanOrEqualTo(1).WithMessage(redisService.GetValueFromCacheAsync("HoseNumberGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.EdsId) 
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("EdsIdGreaterThan").GetAwaiter().GetResult());
-                
-        //    RuleFor(x => x.IdIsland) 
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdIslandGreaterThan").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdIslandNotEmpty").GetAwaiter().GetResult());
-        //}
+            RuleFor(x => x.EdsId)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("EdsIdGreaterThan").GetAwaiter().GetResult());
+
+            RuleFor(x => x.IdIsland)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdIslandGreaterThan").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdIslandNotEmpty").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Dispensers/Queries/GetDispensersById/GetDispensersByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Dispensers/Queries/GetDispensersById/GetDispensersByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Dispensers.Queries.GetDispensersById
 {
     public class GetDispensersByIdQueryValidator : AbstractValidator<GetDispensersByIdQuery>
     {
-        //public GetDispensersByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetDispensersByIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Eds/Commands/CreateEds/CreateEdsCommandValidator.cs
+++ b/Poliedro.Eds.Application/Eds/Commands/CreateEds/CreateEdsCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Poliedro.Eds.Application.Eds.Queries.GetEdsById;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 using System.Net;
 
@@ -7,40 +8,40 @@ namespace Poliedro.Eds.Application.Eds.Commands.CreateEds;
 
 public class CreateEdsCommandValidator : AbstractValidator<CreateEdsRequestDto>
 {
-    //public CreateEdsCommandValidator(ITranslationService translationService)
-    //{
+    public CreateEdsCommandValidator(IRedisService redisService)
+    {
 
-    //    RuleFor(x => x.Name)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotEmpty").GetAwaiter().GetResult())
-    //        .NotEqual("string").WithMessage(translationService.GetTranslationByKey("NameNotEqual").GetAwaiter().GetResult());
+        RuleFor(x => x.Name)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult())
+            .NotEqual("string").WithMessage(redisService.GetValueFromCacheAsync("NameNotEqual").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Nit)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NitNotNull").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NitNotEmpty").GetAwaiter().GetResult()) 
-    //        .NotEqual("string").WithMessage(translationService.GetTranslationByKey("NitNotEqual").GetAwaiter().GetResult());
+        RuleFor(x => x.Nit)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NitNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NitNotEmpty").GetAwaiter().GetResult())
+            .NotEqual("string").WithMessage(redisService.GetValueFromCacheAsync("NitNotEqual").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Address)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("AddressNotNull").GetAwaiter().GetResult()) 
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("AddressNotEmpty").GetAwaiter().GetResult())
-    //        .NotEqual("string").WithMessage(translationService.GetTranslationByKey("AddressNotEqual").GetAwaiter().GetResult());
+        RuleFor(x => x.Address)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AddressNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("AddressNotEmpty").GetAwaiter().GetResult())
+            .NotEqual("string").WithMessage(redisService.GetValueFromCacheAsync("AddressNotEqual").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Sicom)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("SicomNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("SicomNotEmpty").GetAwaiter().GetResult())
-    //        .NotEqual("string").WithMessage(translationService.GetTranslationByKey("SicomNotEqual").GetAwaiter().GetResult());
+        RuleFor(x => x.Sicom)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("SicomNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("SicomNotEmpty").GetAwaiter().GetResult())
+            .NotEqual("string").WithMessage(redisService.GetValueFromCacheAsync("SicomNotEqual").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdBusiness)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdBusinessGreaterThan").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdBusinessNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.IdBusiness)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdBusinessGreaterThan").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdBusinessNotEmpty").GetAwaiter().GetResult());
 
-    //}
-    //public class GetEdsByIdCommandValidator : AbstractValidator<GetEdsByIdQuery>
-    //{
-    //    public GetEdsByIdCommandValidator(ITranslationService translationService)
-    //    {
-    //        RuleFor(x => x.Id)
-    //            .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-    //    }
-    //}
+    }
+    public class GetEdsByIdCommandValidator : AbstractValidator<GetEdsByIdQuery>
+    {
+        public GetEdsByIdCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
+    }
 }

--- a/Poliedro.Eds.Application/Eds/Commands/UpdateEds/UpdateEdsCommandValidator.cs
+++ b/Poliedro.Eds.Application/Eds/Commands/UpdateEds/UpdateEdsCommandValidator.cs
@@ -1,34 +1,35 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Eds.Commands.UpdateEds;
 
 public class UpdateEdsCommandValidator : AbstractValidator<UpdateEdsCommand>
 {
-    //public UpdateEdsCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.IdEds).NotNull().GreaterThan(0) 
-    //         .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdEdsGreaterThan").GetAwaiter().GetResult());
+    public UpdateEdsCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdEds).NotNull().GreaterThan(0)
+             .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdEdsGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Name)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Name)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Nit)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NitNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NitNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Nit)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NitNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NitNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Address)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("AddressNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("AddressNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Address)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AddressNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("AddressNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Sicom)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("SicomNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("SicomNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Sicom)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("SicomNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("SicomNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdBusiness)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdBusinessGreaterThan").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdBusinessNotEmp").GetAwaiter().GetResult());
+        RuleFor(x => x.IdBusiness)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdBusinessGreaterThan").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdBusinessNotEmp").GetAwaiter().GetResult());
 
-    //}
+    }
 }

--- a/Poliedro.Eds.Application/Eds/Queries/GetEdsById/GetEdsByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Eds/Queries/GetEdsById/GetEdsByIdQueryValidator.cs
@@ -10,6 +10,6 @@ public class GetEdsyIdQueryValidator : AbstractValidator<GetEdsByIdQuery>
     {
         RuleFor(x => x.Id)
             .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
-            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdNotGreaterThan").GetAwaiter().GetResult());
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
     }
 }

--- a/Poliedro.Eds.Application/Eds/Queries/GetEdsById/GetEdsByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Eds/Queries/GetEdsById/GetEdsByIdQueryValidator.cs
@@ -1,14 +1,15 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Eds.Queries.GetEdsById;
 
 public class GetEdsyIdQueryValidator : AbstractValidator<GetEdsByIdQuery>
 {
-    //public GetEdsyIdQueryValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Id)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdNotGreaterThan").GetAwaiter().GetResult());
-    //}
+    public GetEdsyIdQueryValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdNotGreaterThan").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/EdsTank/Commands/CreateEdsTank/CreateEdsTankCommandValidator.cs
+++ b/Poliedro.Eds.Application/EdsTank/Commands/CreateEdsTank/CreateEdsTankCommandValidator.cs
@@ -1,18 +1,19 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.EdsTank.Commands.CreateEdsTank;
 
 public class CreateEdsTankCommandValidator : AbstractValidator<CreateEdsTankRequestDto>
 {
-    //public CreateEdsTankCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.IdEds)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdEdsNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdEdsNotEmpty").GetAwaiter().GetResult());
-        
-    //    RuleFor(x => x.IdTank)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdTankNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdTankNotEmpty").GetAwaiter().GetResult());
-    //}
+    public CreateEdsTankCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdEds)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdEdsNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdEdsNotEmpty").GetAwaiter().GetResult());
+
+        RuleFor(x => x.IdTank)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdTankNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdTankNotEmpty").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/EdsTank/Commands/UpdateEdsTank/UpdateEdsTankCommandValidator.cs
+++ b/Poliedro.Eds.Application/EdsTank/Commands/UpdateEdsTank/UpdateEdsTankCommandValidator.cs
@@ -13,7 +13,7 @@ namespace Poliedro.Eds.Application.EdsTank.Commands.UpdateEdsTank;
             .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdEdsNotEmpty").GetAwaiter().GetResult());
 
         RuleFor(x => x.IdTank)
-            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdTank)NotNull").GetAwaiter().GetResult())
-            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdTankNotEmpty)").GetAwaiter().GetResult());
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdTankNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdTankNotEmpty").GetAwaiter().GetResult());
     }
 }

--- a/Poliedro.Eds.Application/EdsTank/Commands/UpdateEdsTank/UpdateEdsTankCommandValidator.cs
+++ b/Poliedro.Eds.Application/EdsTank/Commands/UpdateEdsTank/UpdateEdsTankCommandValidator.cs
@@ -1,18 +1,19 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.EdsTank.Commands.UpdateEdsTank;
 
     public class UpdateEdsTankCommandValidator : AbstractValidator<UpdateEdsTankCommand>
+{
+    public UpdateEdsTankCommandValidator(IRedisService redisService)
     {
-        //public UpdateEdsTankCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.IdEds)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdEdsNotNull").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdEdsNotEmpty").GetAwaiter().GetResult());
-            
-        //    RuleFor(x => x.IdTank)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdTank)NotNull").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdTankNotEmpty)").GetAwaiter().GetResult());
-        //}
+        RuleFor(x => x.IdEds)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdEdsNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdEdsNotEmpty").GetAwaiter().GetResult());
+
+        RuleFor(x => x.IdTank)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdTank)NotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdTankNotEmpty)").GetAwaiter().GetResult());
     }
+}

--- a/Poliedro.Eds.Application/EdsTank/Queries/GetEdsTankById/GetEdsTankByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/EdsTank/Queries/GetEdsTankById/GetEdsTankByIdQueryValidator.cs
@@ -1,13 +1,14 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.EdsTank.Queries.GetEdsTankById;
     public class GetEdsTankByIdQueryValidator : AbstractValidator<GetEdsTankByIdQuery>
     {
-        //public GetEdsTankByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+    public GetEdsTankByIdQueryValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
     }
+}

--- a/Poliedro.Eds.Application/Expenditures/Commands/CreateExpenditures/CreateExpendituresCommandValidator.cs
+++ b/Poliedro.Eds.Application/Expenditures/Commands/CreateExpenditures/CreateExpendituresCommandValidator.cs
@@ -1,16 +1,17 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Expenditures.Commands.CreateExpenditures;
 
 public class CreateExpendituresCommandValidator : AbstractValidator<CreateExpendituresRequestDto>
 {
-    //public CreateExpendituresCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Description)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("DescriptionNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DescriptionNotEmpty").GetAwaiter().GetResult());
-    //}
+    public CreateExpendituresCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Description)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotEmpty").GetAwaiter().GetResult());
+    }
 
 
 }

--- a/Poliedro.Eds.Application/Expenditures/Commands/UpdateExpenditures/UpdateExpendituresCommandValidator.cs
+++ b/Poliedro.Eds.Application/Expenditures/Commands/UpdateExpenditures/UpdateExpendituresCommandValidator.cs
@@ -1,13 +1,14 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Expenditures.Commands.UpdateExpenditures;
     public class UpdateExpendituresCommandValidator : AbstractValidator<UpdateExpendituresCommand>
     {
-        //public UpdateExpendituresCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Description) 
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("DescriptionNotNull").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DescriptionNotEmpty").GetAwaiter().GetResult());
-        //}
+    public UpdateExpendituresCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Description)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotEmpty").GetAwaiter().GetResult());
     }
+}

--- a/Poliedro.Eds.Application/Expenditures/Queries/GetExpendituresById/GetExpendituresByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Expenditures/Queries/GetExpendituresById/GetExpendituresByIdQueryValidator.cs
@@ -1,13 +1,14 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Expenditures.Queries.GetExpendituresById;
     public class GetExpendituresByIdQueryValidator : AbstractValidator<GetExpendituresByIdQuery>
     {
-        //public GetExpendituresByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+    public GetExpendituresByIdQueryValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
     }
+}

--- a/Poliedro.Eds.Application/FileUploadS3/Command/UploadFileValidator.cs
+++ b/Poliedro.Eds.Application/FileUploadS3/Command/UploadFileValidator.cs
@@ -1,14 +1,15 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.FileUploadS3.Command;
 
 public class UploadFileValidator : AbstractValidator<UploadFileCommand>
 {
-    //public UploadFileValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.File)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("FileNotNull").GetAwaiter().GetResult())
-    //        .Must(f => f.Length > 0).WithMessage(translationService.GetTranslationByKey("FileMust").GetAwaiter().GetResult());
-    //}
+    public UploadFileValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.File)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("FileNotNull").GetAwaiter().GetResult())
+            .Must(f => f.Length > 0).WithMessage(redisService.GetValueFromCacheAsync("FileMust").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/Hose/Commands/CreateHose/CreateHoseCommandValidator.cs
+++ b/Poliedro.Eds.Application/Hose/Commands/CreateHose/CreateHoseCommandValidator.cs
@@ -18,6 +18,6 @@ public class CreateHoseCommandValidator : AbstractValidator<CreateHoseRequestDto
 
         RuleFor(x => x.IdProductType)
            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeNotNull").GetAwaiter().GetResult())
-           .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeGreaterThan)").GetAwaiter().GetResult());
+           .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeGreaterThan").GetAwaiter().GetResult());
     }
 }

--- a/Poliedro.Eds.Application/Hose/Commands/CreateHose/CreateHoseCommandValidator.cs
+++ b/Poliedro.Eds.Application/Hose/Commands/CreateHose/CreateHoseCommandValidator.cs
@@ -1,22 +1,23 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Hose.Commands.CreateHose;
 
 public class CreateHoseCommandValidator : AbstractValidator<CreateHoseRequestDto>
 {
-    //public CreateHoseCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Number) 
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NumberNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("NumberGreaterThan").GetAwaiter().GetResult());
+    public CreateHoseCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Number)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NumberNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("NumberGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdDispensers) 
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdDispensersNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdDispensersGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.IdDispensers)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdDispensersNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdDispensersGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdProductType) 
-    //       .NotNull().WithMessage(translationService.GetTranslationByKey("IdProductTypeNotNull").GetAwaiter().GetResult())
-    //       .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdProductTypeGreaterThan)").GetAwaiter().GetResult());
-    //}
+        RuleFor(x => x.IdProductType)
+           .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeNotNull").GetAwaiter().GetResult())
+           .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeGreaterThan)").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/Hose/Commands/UpdateHose/UpdateHoseCommandValidator.cs
+++ b/Poliedro.Eds.Application/Hose/Commands/UpdateHose/UpdateHoseCommandValidator.cs
@@ -1,31 +1,32 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Hose.Commands.UpdateHose
 {
     public class UpdateHoseCommandValidator : AbstractValidator<UpdateHoseCommand>
     {
-        //public UpdateHoseCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Number)
-        //    .NotNull().WithMessage(translationService.GetTranslationByKey("NumberNotNull").GetAwaiter().GetResult())
-        //    .NotEmpty().WithMessage(translationService.GetTranslationByKey("NumberNotEmpty").GetAwaiter().GetResult());
+        public UpdateHoseCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Number)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NumberNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NumberNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdDispensers)  
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdDispensersNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdDispensersGreaterThan").GetAwaiter().GetResult());
+            RuleFor(x => x.IdDispensers)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdDispensersNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdDispensersGreaterThan").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.AccumulatedGallons)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("AccumulatedGallonsNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0.0).WithMessage(translationService.GetTranslationByKey("AccumulatedGallonsGreaterThan").GetAwaiter().GetResult());
+            RuleFor(x => x.AccumulatedGallons)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AccumulatedGallonsNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("AccumulatedGallonsGreaterThan").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.AccumulatedAmount)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("AccumulatedAmountNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0.0).WithMessage(translationService.GetTranslationByKey("AccumulatedAmountGreaterThan").GetAwaiter().GetResult());
+            RuleFor(x => x.AccumulatedAmount)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AccumulatedAmountNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("AccumulatedAmountGreaterThan").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdProductType)
-        //       .NotNull().WithMessage(translationService.GetTranslationByKey("IdProductTypeNotNull").GetAwaiter().GetResult())
-        //       .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdProductTypeGreaterThan").GetAwaiter().GetResult());
-        //}
+            RuleFor(x => x.IdProductType)
+               .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeNotNull").GetAwaiter().GetResult())
+               .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Hose/Queries/GetHoseById/GetHoseByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Hose/Queries/GetHoseById/GetHoseByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Hose.Queries.GetHoseById
 {
     public class GetHoseIdQueryValidator : AbstractValidator<GetHoseByIdQuery>
     {
-        //public GetHoseIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetHoseIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Hose/Queries/GetLastAccumulated/GetLastAccumulatedQueryValidator.cs
+++ b/Poliedro.Eds.Application/Hose/Queries/GetLastAccumulated/GetLastAccumulatedQueryValidator.cs
@@ -1,19 +1,20 @@
 ﻿using FluentValidation;
 using Poliedro.Eds.Application.Hose.Queries.GetLastAccumulated;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Hose.Queries.GetHoseById
 {
     public class GetLastAccumulatedQueryValidator : AbstractValidator<GetLastAccumulatedQuery>
     {
-        //public GetLastAccumulatedQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.idDispenser)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("idDispenserNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("idDispenserGreaterThan").GetAwaiter().GetResult());
-        //    RuleFor(x => x.idHose)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("idHoseNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("idHoseGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetLastAccumulatedQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.idDispenser)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("idDispenserNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("idDispenserGreaterThan").GetAwaiter().GetResult());
+            RuleFor(x => x.idHose)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("idHoseNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("idHoseGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/HoseHistory/Commands/CreateHoseHistory/CreateHoseHistoryCommandValidator.cs
+++ b/Poliedro.Eds.Application/HoseHistory/Commands/CreateHoseHistory/CreateHoseHistoryCommandValidator.cs
@@ -1,32 +1,33 @@
 ﻿using FluentValidation;
 using Microsoft.Extensions.Hosting;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.HoseHistory.Commands.CreateHoseHistory;
 
 public class CreateHoseHistoryCommandValidator : AbstractValidator<CreateHoseHistoryRequestDto>
 {
-    //public CreateHoseHistoryCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.IdHose) 
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdHoseNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdHoseGreaterThan").GetAwaiter().GetResult());
+    public CreateHoseHistoryCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdHose)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdHoseNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdHoseGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.AccumulatedGallons)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("AccumulatedGallonsNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0.0).WithMessage(translationService.GetTranslationByKey("AccumulatedGallonsGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.AccumulatedGallons)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AccumulatedGallonsNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("AccumulatedGallonsGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.AccumulatedAmount)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("AccumulatedAmountNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0.0).WithMessage(translationService.GetTranslationByKey("AccumulatedAmountGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.AccumulatedAmount)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AccumulatedAmountNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("AccumulatedAmountGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdDispensers)
-    //       .NotNull().WithMessage(translationService.GetTranslationByKey("IdDispensersNotNull").GetAwaiter().GetResult())
-    //       .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdDispensersGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.IdDispensers)
+           .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdDispensersNotNull").GetAwaiter().GetResult())
+           .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdDispensersGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Date)
-    //       .NotNull().WithMessage(translationService.GetTranslationByKey("DateNotNull").GetAwaiter().GetResult())
-    //       .GreaterThan(DateTime.MinValue).WithMessage(translationService.GetTranslationByKey("DateGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.Date)
+           .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DateNotNull").GetAwaiter().GetResult())
+           .GreaterThan(DateTime.MinValue).WithMessage(redisService.GetValueFromCacheAsync("DateGreaterThan").GetAwaiter().GetResult());
 
-    //}
+    }
 }

--- a/Poliedro.Eds.Application/HoseHistory/Commands/UpdateHoseHistory/UpdateHoseHistoryCommandValidator.cs
+++ b/Poliedro.Eds.Application/HoseHistory/Commands/UpdateHoseHistory/UpdateHoseHistoryCommandValidator.cs
@@ -1,35 +1,36 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.HoseHistory.Commands.UpdateHoseHistory
 {
     public class UpdateHoseHistoryCommandValidator : AbstractValidator<UpdateHoseHistoryCommand>
     {
-    //    public UpdateHoseHistoryCommandValidator(ITranslationService translationService)
-    //    {
-    //        RuleFor(x => x.IdHoseHistory)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NotNullIdHoseHistory").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("GreaterThanIdHoseHistory").GetAwaiter().GetResult());
+        public UpdateHoseHistoryCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.IdHoseHistory)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NotNullIdHoseHistory").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("GreaterThanIdHoseHistory").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.IdHose)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("IdHoseNotNull").GetAwaiter().GetResult())
-    //            .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdHoseGreaterThan").GetAwaiter().GetResult());
+            RuleFor(x => x.IdHose)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdHoseNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdHoseGreaterThan").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.AccumulatedGallons)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("AccumulatedGallonsNotNull").GetAwaiter().GetResult())
-    //            .GreaterThan(0.0).WithMessage(translationService.GetTranslationByKey("AccumulatedGallonsGreaterThan").GetAwaiter().GetResult());
+            RuleFor(x => x.AccumulatedGallons)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AccumulatedGallonsNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("AccumulatedGallonsGreaterThan").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.AccumulatedAmount)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("AccumulatedAmountNotNull").GetAwaiter().GetResult())
-    //            .GreaterThan(0.0).WithMessage(translationService.GetTranslationByKey("AccumulatedAmountGreaterThan").GetAwaiter().GetResult());
+            RuleFor(x => x.AccumulatedAmount)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AccumulatedAmountNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("AccumulatedAmountGreaterThan").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.IdDispensers)
-    //           .NotNull().WithMessage(translationService.GetTranslationByKey("IdDispensersNotNull").GetAwaiter().GetResult())
-    //           .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdDispensersGreaterThan").GetAwaiter().GetResult());
+            RuleFor(x => x.IdDispensers)
+               .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdDispensersNotNull").GetAwaiter().GetResult())
+               .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdDispensersGreaterThan").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.Date)
-    //           .NotNull().WithMessage(translationService.GetTranslationByKey("DateNotNull").GetAwaiter().GetResult())
-    //           .GreaterThan(DateTime.MinValue).WithMessage(translationService.GetTranslationByKey("DateGreaterThan").GetAwaiter().GetResult());
-    //    }
+            RuleFor(x => x.Date)
+               .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DateNotNull").GetAwaiter().GetResult())
+               .GreaterThan(DateTime.MinValue).WithMessage(redisService.GetValueFromCacheAsync("DateGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/HoseHistory/Queries/GetHoseHistoryById/GetHoseHistoryByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/HoseHistory/Queries/GetHoseHistoryById/GetHoseHistoryByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.HoseHistory.Queries.GetHoseHistoryById
 {
     public class GetHoseHistoryIdQueryValidator : AbstractValidator<GetHoseHistoryByIdQuery>
     {
-        //public GetHoseHistoryIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetHoseHistoryIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Island/Commands/CreateIsland/CreateIslandCommandValidator.cs
+++ b/Poliedro.Eds.Application/Island/Commands/CreateIsland/CreateIslandCommandValidator.cs
@@ -1,14 +1,15 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Island.Commands.CreateIsland;
 
 public class CreateIslandCommandValidator : AbstractValidator<CreateIslandRequestDto>
 {
-    //public CreateIslandCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Description)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotEmpty").GetAwaiter().GetResult());
-    //}
+    public CreateIslandCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Description)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/Island/Commands/UpdateIsland/UpdateIslandCommandValidator.cs
+++ b/Poliedro.Eds.Application/Island/Commands/UpdateIsland/UpdateIslandCommandValidator.cs
@@ -1,18 +1,19 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Island.Commands.UpdateIsland
 {
     public class UpdateIslandCommandValidator : AbstractValidator<UpdateIslandCommand>
     {
-        //public UpdateIslandCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Description)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotEmpty").GetAwaiter().GetResult());
+        public UpdateIslandCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Description)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdIsland).NotNull().GreaterThan(0)
-        //         .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdEdsGreaterThan").GetAwaiter().GetResult());
-        //}
+            RuleFor(x => x.IdIsland).NotNull().GreaterThan(0)
+                 .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdEdsGreaterThan").GetAwaiter().GetResult());
+        }
     }
 } 

--- a/Poliedro.Eds.Application/Island/Queries/GetIslandById/GetIslandByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Island/Queries/GetIslandById/GetIslandByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Island.Queries.GetIslandById
 {
     public class GetIslandyIdQueryValidator : AbstractValidator<GetIslandByIdQuery>
     {
-        //public GetIslandyIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetIslandyIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Islander/Commands/CreateIslander/CreateIslanderCommandValidator.cs
+++ b/Poliedro.Eds.Application/Islander/Commands/CreateIslander/CreateIslanderCommandValidator.cs
@@ -1,22 +1,23 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Islander.Commands.CreateIslander;
 
 public class CreateIslanderCommandValidator : AbstractValidator<CreateIslanderRequestDto>
 {
-    //public CreateIslanderCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Name)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotEmpty").GetAwaiter().GetResult());
+    public CreateIslanderCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Name)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdEds)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdEdsNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdEdsNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.IdEds)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdEdsNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdEdsNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Password)
-    //       .NotNull().WithMessage(translationService.GetTranslationByKey("PasswordNotNull").GetAwaiter().GetResult())
-    //       .NotEmpty().WithMessage(translationService.GetTranslationByKey("PasswordNotEmpty").GetAwaiter().GetResult());
-    //}
+        RuleFor(x => x.Password)
+           .NotNull().WithMessage(redisService.GetValueFromCacheAsync("PasswordNotNull").GetAwaiter().GetResult())
+           .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("PasswordNotEmpty").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/Islander/Commands/UpdateIslander/UpdateIslanderCommandValidator.cs
+++ b/Poliedro.Eds.Application/Islander/Commands/UpdateIslander/UpdateIslanderCommandValidator.cs
@@ -1,18 +1,19 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Islander.Commands.UpdateIslander
 {
     public class UpdateIslanderCommandValidator : AbstractValidator<UpdateIslanderCommand>
     {
-        //public UpdateIslanderCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Name)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotEmpty").GetAwaiter().GetResult());
+        public UpdateIslanderCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Name)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdEds).NotNull().GreaterThan(0)
-        //         .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdEdsGreaterThan").GetAwaiter().GetResult());
-        //}
+            RuleFor(x => x.IdEds).NotNull().GreaterThan(0)
+                 .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdEdsGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Islander/Queries/GetIslanderById/GetIslanderByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Islander/Queries/GetIslanderById/GetIslanderByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Islander.Queries.GetIslanderById
 {
     public class GetIslanderyIdQueryValidator : AbstractValidator<GetIslanderByIdQuery>
     {
-        //public GetIslanderyIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetIslanderyIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Product/Commands/CreateProduct/CreateProductCommandValidator.cs
+++ b/Poliedro.Eds.Application/Product/Commands/CreateProduct/CreateProductCommandValidator.cs
@@ -1,25 +1,26 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Product.Commands.CreateProduct;
 
 public class CreateProductCommandValidator : AbstractValidator<CreateProductRequestDto>
 {
-    //public CreateProductCommandValidator(ITranslationService translationService)
-    //{
+    public CreateProductCommandValidator(IRedisService redisService)
+    {
 
-    //    RuleFor(x => x.Name)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Name)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdProductType)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdProductTypeNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdProductTypeNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.IdProductType)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Price)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("PriceNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("PriceNotEmpty").GetAwaiter().GetResult());
-    //}
+        RuleFor(x => x.Price)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("PriceNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("PriceNotEmpty").GetAwaiter().GetResult());
+    }
 
 
 }

--- a/Poliedro.Eds.Application/Product/Commands/UpdateProduct/UpdateProductCommandValidator.cs
+++ b/Poliedro.Eds.Application/Product/Commands/UpdateProduct/UpdateProductCommandValidator.cs
@@ -1,25 +1,26 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Product.Commands.UpdateProduct
 {
     public class UpdateProductCommandValidator : AbstractValidator<UpdateProductCommand>
     {
-    //    public UpdateProductCommandValidator(ITranslationService translationService)
-    //    {
-    //        RuleFor(x => x.Name)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotEmpty").GetAwaiter().GetResult());
-            
-    //        RuleFor(x => x.IdProductType)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("IdProductTypeNotNull").GetAwaiter().GetResult())
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdProductTypeNotEmpty").GetAwaiter().GetResult());
-            
-    //        RuleFor(x => x.Price)
-    //            .NotNull().WithMessage(translationService.GetTranslationByKey("PriceNotNull").GetAwaiter().GetResult())
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("PriceNotEmpty").GetAwaiter().GetResult());
+        public UpdateProductCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Name)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult());
+
+            RuleFor(x => x.IdProductType)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdProductTypeNotEmpty").GetAwaiter().GetResult());
+
+            RuleFor(x => x.Price)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("PriceNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("PriceNotEmpty").GetAwaiter().GetResult());
 
 
-    //    }
+        }
     }
 }

--- a/Poliedro.Eds.Application/Product/Queries/GetProductById/GetProductByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Product/Queries/GetProductById/GetProductByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Product.Queries.GetProductById
 {
     public class GetProductByIdQueryValidator : AbstractValidator<GetProductByIdQuery>
     {
-        //public GetProductByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetProductByIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/ProductCompartiment/Commands/CreateProductCompartiment/CreateProductCompartimentCommandValidator.cs
+++ b/Poliedro.Eds.Application/ProductCompartiment/Commands/CreateProductCompartiment/CreateProductCompartimentCommandValidator.cs
@@ -1,22 +1,23 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.ProductCompartiment.Commands.CreateProductCompartiment;
 
 public class CreateProductCompartimentCommandValidator : AbstractValidator<CreateProductCompartimentRequestDto>
 {
-    //public CreateProductCompartimentCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.IdProduct)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdProductNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdProductNotEmpty").GetAwaiter().GetResult());
-        
-    //    RuleFor(x => x.IdCompartiment)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdCompartimentNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdCompartimentNotEmpty").GetAwaiter().GetResult());
+    public CreateProductCompartimentCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdProduct)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdProductNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdProductNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Stock)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("StockNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("StockNotEmpty").GetAwaiter().GetResult());
-    //}
+        RuleFor(x => x.IdCompartiment)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdCompartimentNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdCompartimentNotEmpty").GetAwaiter().GetResult());
+
+        RuleFor(x => x.Stock)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("StockNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("StockNotEmpty").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/ProductCompartiment/Commands/UpdateProductCompartiment/UpdateProductCompartimentCommandValidator.cs
+++ b/Poliedro.Eds.Application/ProductCompartiment/Commands/UpdateProductCompartiment/UpdateProductCompartimentCommandValidator.cs
@@ -1,23 +1,24 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.ProductCompartiment.Commands.UpdateProductCompartiment
 {
     public class UpdateProductCompartimentCommandValidator : AbstractValidator<UpdateProductCompartimentCommand>
     {
-        //public UpdateProductCompartimentCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.IdProduct)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdProductNotNull").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdProductNotEmpty").GetAwaiter().GetResult());
-            
-        //    RuleFor(x => x.IdProductCompartiment)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdProductCompartimentNotNull").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdProductCompartimentNotEmpty").GetAwaiter().GetResult());
-            
-        //    RuleFor(x => x.Stock)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("StockNotNull").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("StockNotEmpty").GetAwaiter().GetResult());
-        //}
+        public UpdateProductCompartimentCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.IdProduct)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdProductNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdProductNotEmpty").GetAwaiter().GetResult());
+
+            RuleFor(x => x.IdProductCompartiment)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdProductCompartimentNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdProductCompartimentNotEmpty").GetAwaiter().GetResult());
+
+            RuleFor(x => x.Stock)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("StockNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("StockNotEmpty").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/ProductCompartiment/Queries/GetProductCompartimentById/GetProductCompartimentByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/ProductCompartiment/Queries/GetProductCompartimentById/GetProductCompartimentByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.ProductCompartiment.Queries.GetProductCompartimentById
 {
     public class GetProductCompartimentByIdQueryValidator : AbstractValidator<GetProductCompartimentByIdQuery>
     {
-        //public GetProductCompartimentByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetProductCompartimentByIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/ProductType/Commands/CreateProductType/CreateProductTypeCommandValidator.cs
+++ b/Poliedro.Eds.Application/ProductType/Commands/CreateProductType/CreateProductTypeCommandValidator.cs
@@ -1,18 +1,19 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.ProductType.Commands.CreateProductType;
 
 public class CreateProductTypeCommandValidator : AbstractValidator<CreateProductTypeRequestDto>
 {
-    //public CreateProductTypeCommandValidator(ITranslationService translationService)
-    //{
+    public CreateProductTypeCommandValidator(IRedisService redisService)
+    {
 
-    //    RuleFor(x => x.Description)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("DescriptionNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DescriptionNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Description)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotEmpty").GetAwaiter().GetResult());
 
-    //}
+    }
 
 
 }

--- a/Poliedro.Eds.Application/ProductType/Commands/UpdateProductType/UpdateProductTypeCommandValidator.cs
+++ b/Poliedro.Eds.Application/ProductType/Commands/UpdateProductType/UpdateProductTypeCommandValidator.cs
@@ -1,17 +1,18 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.ProductType.Commands.UpdateProductType
 {
     public class UpdateProductTypeCommandValidator : AbstractValidator<UpdateProductTypeCommand>
     {
-        //public UpdateProductTypeCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Description)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("DescriptionNotNull").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DescriptionNotEmpty").GetAwaiter().GetResult());
+        public UpdateProductTypeCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Description)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotNull").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotEmpty").GetAwaiter().GetResult());
 
 
-        //}
+        }
     }
 }

--- a/Poliedro.Eds.Application/ProductType/Queries/GetProductTypeById/GetProductTypeByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/ProductType/Queries/GetProductTypeById/GetProductTypeByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.ProductType.Queries.GetProductTypeById
 {
     public class GetProductTypeByIdQueryValidator : AbstractValidator<GetProductTypeByIdQuery>
     {
-        //public GetProductTypeByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetProductTypeByIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Provider/Commands/CreateProvider/CreateProviderCommandValidator.cs
+++ b/Poliedro.Eds.Application/Provider/Commands/CreateProvider/CreateProviderCommandValidator.cs
@@ -11,8 +11,8 @@ public class CreateProviderCommandValidator : AbstractValidator<CreateProviderRe
     {
         RuleFor(x => x.Name)
             .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
-            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
-            .NotEqual("string").WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult());
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult())
+            .NotEqual("string").WithMessage(redisService.GetValueFromCacheAsync("NameNotEqual").GetAwaiter().GetResult());
     }
     public class GetProviderByIdCommandValidator : AbstractValidator<GetProviderByIdQuery>
     {

--- a/Poliedro.Eds.Application/Provider/Commands/CreateProvider/CreateProviderCommandValidator.cs
+++ b/Poliedro.Eds.Application/Provider/Commands/CreateProvider/CreateProviderCommandValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 using Poliedro.Eds.Application.Provider.Queries.GetProviderById;
 
@@ -6,19 +7,19 @@ namespace Poliedro.Eds.Application.Provider.Commands.CreateProvider;
 
 public class CreateProviderCommandValidator : AbstractValidator<CreateProviderRequestDto>
 {
-    //public CreateProviderCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Name)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-    //        .NotEqual("string").WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult());
-    //}
-    //public class GetProviderByIdCommandValidator : AbstractValidator<GetProviderByIdQuery>
-    //{
-    //    public GetProviderByIdCommandValidator(ITranslationService translationService)
-    //    {
-    //        RuleFor(x => x.Id)
-    //            .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-    //    }
-    //}
+    public CreateProviderCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Name)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+            .NotEqual("string").WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult());
+    }
+    public class GetProviderByIdCommandValidator : AbstractValidator<GetProviderByIdQuery>
+    {
+        public GetProviderByIdCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
+    }
 }

--- a/Poliedro.Eds.Application/Provider/Commands/UpdateProvider/UpdateProviderCommandValidator.cs
+++ b/Poliedro.Eds.Application/Provider/Commands/UpdateProvider/UpdateProviderCommandValidator.cs
@@ -1,17 +1,18 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Provider.Commands.UpdateProvider;
 
 public class UpdateProviderCommandValidator : AbstractValidator<UpdateProviderCommand>
 {
-    //public UpdateProviderCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.IdProvider).NotNull().GreaterThan(0) 
-    //         .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdProviderGreaterThan").GetAwaiter().GetResult());
+    public UpdateProviderCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdProvider).NotNull().GreaterThan(0)
+             .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdProviderGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Name)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NameNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NameNotEmpty").GetAwaiter().GetResult());
-    //}
+        RuleFor(x => x.Name)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NameNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NameNotEmpty").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/Provider/Queries/GetProviderById/GetProviderByIdValidator.cs
+++ b/Poliedro.Eds.Application/Provider/Queries/GetProviderById/GetProviderByIdValidator.cs
@@ -1,13 +1,14 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Provider.Queries.GetProviderById;
 public class GetProviderIdQueryValidator : AbstractValidator<GetProviderByIdQuery>
 {
-    //public GetProviderIdQueryValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Id)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-    //}
+    public GetProviderIdQueryValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/Shopping/Commands/CreateShopping/CreateShoppingCommandValidator.cs
+++ b/Poliedro.Eds.Application/Shopping/Commands/CreateShopping/CreateShoppingCommandValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 using Poliedro.Eds.Application.Shopping.Commands.CreateShopping;
 using Poliedro.Eds.Application.Shopping.Commands.UpdateShopping;
@@ -7,23 +8,23 @@ namespace Poliedro.Eds.Application.Shopping.Shopping.CreateShopping;
 
 public class CreateShoppingCommandValidator : AbstractValidator<CreateShoppingRequestDto>
 {
-    //public CreateShoppingCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Invoice)
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("InvoiceNotEmpty)").GetAwaiter().GetResult())
-    //        .MaximumLength(45).WithMessage(translationService.GetTranslationByKey("InvoiceMaximumLength)").GetAwaiter().GetResult());
+    public CreateShoppingCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Invoice)
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("InvoiceNotEmpty)").GetAwaiter().GetResult())
+            .MaximumLength(45).WithMessage(redisService.GetValueFromCacheAsync("InvoiceMaximumLength)").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Date)
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DateNotEmpty").GetAwaiter().GetResult())
-    //        .Must(date => date != default(DateTime)).WithMessage(translationService.GetTranslationByKey("DateMust").GetAwaiter().GetResult());
+        RuleFor(x => x.Date)
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DateNotEmpty").GetAwaiter().GetResult())
+            .Must(date => date != default(DateTime)).WithMessage(redisService.GetValueFromCacheAsync("DateMust").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdProvider)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdProviderGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.IdProvider)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdProviderGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdCategory)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdCategoryGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.IdCategory)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdCategoryGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Amount)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("AmountGreaterThan").GetAwaiter().GetResult());
-    //}
+        RuleFor(x => x.Amount)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("AmountGreaterThan").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/Shopping/Commands/UpdateShopping/UpdateShoppingCommandValidator.cs
+++ b/Poliedro.Eds.Application/Shopping/Commands/UpdateShopping/UpdateShoppingCommandValidator.cs
@@ -7,7 +7,7 @@ namespace Poliedro.Eds.Application.Shopping.Commands.UpdateShopping;
     public UpdateShoppingCommandValidator(IRedisService redisService)
     {
         RuleFor(x => x.IdShopping)
-            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdShoppingGreaterThan)").GetAwaiter().GetResult());
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdShoppingGreaterThan").GetAwaiter().GetResult());
 
         RuleFor(x => x.Invoice)
             .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("InvoiceNotEmpty").GetAwaiter().GetResult())

--- a/Poliedro.Eds.Application/Shopping/Commands/UpdateShopping/UpdateShoppingCommandValidator.cs
+++ b/Poliedro.Eds.Application/Shopping/Commands/UpdateShopping/UpdateShoppingCommandValidator.cs
@@ -1,29 +1,30 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 namespace Poliedro.Eds.Application.Shopping.Commands.UpdateShopping;
     public class UpdateShoppingCommandValidator : AbstractValidator<UpdateShoppingCommand>
     {
-        //public UpdateShoppingCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.IdShopping)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdShoppingGreaterThan)").GetAwaiter().GetResult());
+    public UpdateShoppingCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdShopping)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdShoppingGreaterThan)").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Invoice)
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("InvoiceNotEmpty").GetAwaiter().GetResult())
-        //        .MaximumLength(45).WithMessage(translationService.GetTranslationByKey("InvoiceMaximumLength").GetAwaiter().GetResult());
+        RuleFor(x => x.Invoice)
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("InvoiceNotEmpty").GetAwaiter().GetResult())
+            .MaximumLength(45).WithMessage(redisService.GetValueFromCacheAsync("InvoiceMaximumLength").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Date)
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DateNotEmpty").GetAwaiter().GetResult())
-        //        .Must(date => date != default(DateTime)).WithMessage(translationService.GetTranslationByKey("DateMust").GetAwaiter().GetResult());
+        RuleFor(x => x.Date)
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DateNotEmpty").GetAwaiter().GetResult())
+            .Must(date => date != default(DateTime)).WithMessage(redisService.GetValueFromCacheAsync("DateMust").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdProvider)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdProviderGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.IdProvider)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdProviderGreaterThan").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdCategory)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdCategoryGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.IdCategory)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdCategoryGreaterThan").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Amount)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("AmountGreaterThan").GetAwaiter().GetResult());
-        //}
+        RuleFor(x => x.Amount)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("AmountGreaterThan").GetAwaiter().GetResult());
     }
+}
 

--- a/Poliedro.Eds.Application/Shopping/Queries/GetShoppingById/GetShoppingByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Shopping/Queries/GetShoppingById/GetShoppingByIdQueryValidator.cs
@@ -1,14 +1,15 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Shopping.Queries.GetShoppingById;
 
     public class GetShoppingByIdQueryValidator : AbstractValidator<GetShoppingByIdQuery>
     {
-        //public GetShoppingByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+    public GetShoppingByIdQueryValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
     }
+}

--- a/Poliedro.Eds.Application/ShoppingProduct/Commands/CreateShoppingProduct/CreateShoppingProductCommandValidator.cs
+++ b/Poliedro.Eds.Application/ShoppingProduct/Commands/CreateShoppingProduct/CreateShoppingProductCommandValidator.cs
@@ -51,26 +51,26 @@ public class CreateShoppingProductCommandValidator : AbstractValidator<CreateSho
 
     }
 
-    //public CreateShoppingProductCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.IdShopping)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdShoppingGreaterThan").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdShoppingNotEmpty").GetAwaiter().GetResult());
+    public CreateShoppingProductCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdShopping)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdShoppingGreaterThan").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdShoppingNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdProduct)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdProductGreaterThan").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdProductNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.IdProduct)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdProductGreaterThan").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdProductNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Quantity)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("QuantityGreaterThan").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("QuantityNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Quantity)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("QuantityGreaterThan").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("QuantityNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Price)
-    //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("PriceGreaterThanOrEqualTo").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("PriceNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Price)
+            .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("PriceGreaterThanOrEqualTo").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("PriceNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.IdCompartment)
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdCompartmentGreaterThan").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdCompartmentNotEmpty").GetAwaiter().GetResult());
-    //}
+        RuleFor(x => x.IdCompartment)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdCompartmentGreaterThan").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdCompartmentNotEmpty").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/ShoppingProduct/Commands/UpdateShopping/UpdateShoppingProductCommandValidator.cs
+++ b/Poliedro.Eds.Application/ShoppingProduct/Commands/UpdateShopping/UpdateShoppingProductCommandValidator.cs
@@ -1,34 +1,35 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 using Poliedro.Eds.Application.ShoppingProduct.Commands.UpdateShoppingProduct;
 namespace Poliedro.Eds.Application.Shopping.Commands.UpdateShoppingProduct;
     public class UpdateShoppingProductCommandValidator : AbstractValidator<UpdateShoppingProductCommand>
     {
-        //public UpdateShoppingProductCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.IdShoppingProduct)
-        //    .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("GreaterThanIdShoppingProduct").GetAwaiter().GetResult())
-        //    .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdShoppingProductNotEmpty").GetAwaiter().GetResult());
+    public UpdateShoppingProductCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.IdShoppingProduct)
+        .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("GreaterThanIdShoppingProduct").GetAwaiter().GetResult())
+        .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdShoppingProductNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdShopping)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("GreaterThanIdShopping").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NotEmptyIdShopping").GetAwaiter().GetResult());
+        RuleFor(x => x.IdShopping)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("GreaterThanIdShopping").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NotEmptyIdShopping").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdProduct)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdProductGreaterThan").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdProductNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.IdProduct)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdProductGreaterThan").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdProductNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Quantity)
-        //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("QuantityGreaterThanOrEqualTo").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("QuantityNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Quantity)
+            .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("QuantityGreaterThanOrEqualTo").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("QuantityNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.Price)
-        //        .GreaterThanOrEqualTo(0).WithMessage(translationService.GetTranslationByKey("PriceGreaterThanOrEqualTo").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("PriceNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Price)
+            .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("PriceGreaterThanOrEqualTo").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("PriceNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdCompartment)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdCompartmentGreaterThan").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdCompartmentNotEmpty").GetAwaiter().GetResult());
-        //}
+        RuleFor(x => x.IdCompartment)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdCompartmentGreaterThan").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdCompartmentNotEmpty").GetAwaiter().GetResult());
     }
+}
 

--- a/Poliedro.Eds.Application/ShoppingProduct/Queries/GetShoppingProductById/GetShoppingProductByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/ShoppingProduct/Queries/GetShoppingProductById/GetShoppingProductByIdQueryValidator.cs
@@ -1,13 +1,14 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.ShoppingProduct.Queries.GetShoppingProductById;
     public class GetShoppingProductByIdQueryValidator : AbstractValidator<GetShoppingProductByIdQuery>
+{
+    public GetShoppingProductByIdQueryValidator(IRedisService redisService)
     {
-        //public GetShoppingProductByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
     }
+}

--- a/Poliedro.Eds.Application/ShoppingProductInventory/Commands/CreateShoppingProductInventory/CreateShoppingProductInventoryCommandValidator.cs
+++ b/Poliedro.Eds.Application/ShoppingProductInventory/Commands/CreateShoppingProductInventory/CreateShoppingProductInventoryCommandValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 using Poliedro.Eds.Application.ShoppingProduct.Commands.CreateShoppingProduct;
 using System;
@@ -11,19 +12,19 @@ namespace Poliedro.Eds.Application.ShoppingProductInventory.Commands.CreateShopp
 {
     public class CreateShoppingProductInventoryCommandValidator : AbstractValidator<CreateShoppingProductInventoryRequestDto>
     {
-    //    public CreateShoppingProductInventoryCommandValidator(ITranslationService translationService)
-    //    {
-    //        RuleFor(x => x.IdShoppingProductInventory)
-    //       .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdShoppingProductInventoryGreaterThan").GetAwaiter().GetResult())
-    //       .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdShoppingProductInventoryNotEmpty").GetAwaiter().GetResult());
+        public CreateShoppingProductInventoryCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.IdShoppingProductInventory)
+           .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdShoppingProductInventoryGreaterThan").GetAwaiter().GetResult())
+           .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdShoppingProductInventoryNotEmpty").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.IdShoppingProduct)
-    //            .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdShoppingProductGreaterThan").GetAwaiter().GetResult())
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdShoppingProductNotEmpty").GetAwaiter().GetResult());
+            RuleFor(x => x.IdShoppingProduct)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdShoppingProductGreaterThan").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdShoppingProductNotEmpty").GetAwaiter().GetResult());
 
-    //        RuleFor(x => x.IdInventory)
-    //            .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdInventoryGreaterThan").GetAwaiter().GetResult())
-    //            .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdInventoryNotEmpty").GetAwaiter().GetResult());
-    //    }
+            RuleFor(x => x.IdInventory)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdInventoryGreaterThan").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdInventoryNotEmpty").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/ShoppingProductInventory/Commands/UpdateShoppingProductInventory/UpdateShoppingProductInventoryCommandValidator.cs
+++ b/Poliedro.Eds.Application/ShoppingProductInventory/Commands/UpdateShoppingProductInventory/UpdateShoppingProductInventoryCommandValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 using System;
 using System.Collections.Generic;
@@ -10,19 +11,19 @@ namespace Poliedro.Eds.Application.ShoppingProductInventory.Commands.UpdateShopp
 {
     public class UpdateShoppingProductInventoryCommandValidator :  AbstractValidator<UpdateShoppingProductInventoryCommand>
     {
-        //public UpdateShoppingProductInventoryCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.IdShopping)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdShoppingGreaterThan").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdShoppingNotEmpty").GetAwaiter().GetResult());
+        public UpdateShoppingProductInventoryCommandValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.IdShopping)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdShoppingGreaterThan").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdShoppingNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdInventory)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdInventoryGreaterThan").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdInventoryNotEmpty").GetAwaiter().GetResult());
+            RuleFor(x => x.IdInventory)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdInventoryGreaterThan").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdInventoryNotEmpty").GetAwaiter().GetResult());
 
-        //    RuleFor(x => x.IdShoppingProduct)
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdShoppingProductGreaterThan").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("IdShoppingProductNotEmpty").GetAwaiter().GetResult());
-        //}
+            RuleFor(x => x.IdShoppingProduct)
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdShoppingProductGreaterThan").GetAwaiter().GetResult())
+                .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("IdShoppingProductNotEmpty").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/ShoppingProductInventory/Queries/GetShoppingProductInventoryById/GetShoppingProductInventoryByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/ShoppingProductInventory/Queries/GetShoppingProductInventoryById/GetShoppingProductInventoryByIdQueryValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 using Poliedro.Eds.Application.ShoppingProduct.Queries.GetShoppingProductById;
 using Poliedro.Eds.Application.ShoppingProductInventory.Queries.GetShoppingProductInventoryById;
@@ -12,11 +13,11 @@ namespace Poliedro.Eds.Application.ShoppingProductInventory.Queries.GetShoppingP
 {
     public class GetShoppingProductInventoryByIdQueryValidator : AbstractValidator<GetShoppingProductInventoryByIdQuery>
     {
-        //public GetShoppingProductInventoryByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetShoppingProductInventoryByIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/Tank/Commands/CreateTank/CreateTankCommandValidator.cs
+++ b/Poliedro.Eds.Application/Tank/Commands/CreateTank/CreateTankCommandValidator.cs
@@ -1,27 +1,28 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Tank.Commands.CreateTank;
 
 public class CreateTankCommandValidator : AbstractValidator<CreateTankRequestDto>
 {
-    //public CreateTankCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Number)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("NumberNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("NumberNotEmpty").GetAwaiter().GetResult());
+    public CreateTankCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Number)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NumberNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NumberNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Compartment)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("CompartmentNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("CompartmentGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.Compartment)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("CompartmentNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("CompartmentGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Ability)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("AbilityNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0.0).WithMessage(translationService.GetTranslationByKey("AbilityGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.Ability)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AbilityNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("AbilityGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Stock)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("StockNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0.0).WithMessage(translationService.GetTranslationByKey("StockGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.Stock)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("StockNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("StockGreaterThan").GetAwaiter().GetResult());
 
-    //}
+    }
 }

--- a/Poliedro.Eds.Application/Tank/Commands/UpdateTank/UpdateTankCommandValidator.cs
+++ b/Poliedro.Eds.Application/Tank/Commands/UpdateTank/UpdateTankCommandValidator.cs
@@ -1,26 +1,27 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Tank.Commands.UpdateTank;
 
 public class UpdateTankCommandValidator : AbstractValidator<UpdateTankCommand>
 {
-    //public UpdateTankCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Number)
-    //    .NotNull().WithMessage(translationService.GetTranslationByKey("NumberNotNull").GetAwaiter().GetResult())
-    //    .NotEmpty().WithMessage(translationService.GetTranslationByKey("NumberNotEmpty").GetAwaiter().GetResult());
+    public UpdateTankCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Number)
+        .NotNull().WithMessage(redisService.GetValueFromCacheAsync("NumberNotNull").GetAwaiter().GetResult())
+        .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("NumberNotEmpty").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Compartment)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("CompartmentNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("CompartmentGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.Compartment)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("CompartmentNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("CompartmentGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Ability)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("AbilityNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0.0).WithMessage(translationService.GetTranslationByKey("AbilityGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.Ability)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AbilityNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("AbilityGreaterThan").GetAwaiter().GetResult());
 
-    //    RuleFor(x => x.Stock)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("StockNotNull").GetAwaiter().GetResult())
-    //        .GreaterThan(0.0).WithMessage(translationService.GetTranslationByKey("StockGreaterThan").GetAwaiter().GetResult());
-    //}
+        RuleFor(x => x.Stock)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("StockNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("StockGreaterThan").GetAwaiter().GetResult());
+    }
 }

--- a/Poliedro.Eds.Application/Tank/Queries/GetTankById/GetTankByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/Tank/Queries/GetTankById/GetTankByIdQueryValidator.cs
@@ -1,15 +1,16 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.Tank.Queries.GetTankById
 {
     public class GetTankIdQueryValidator : AbstractValidator<GetTankByIdQuery>
     {
-        //public GetTankIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+        public GetTankIdQueryValidator(IRedisService redisService)
+        {
+            RuleFor(x => x.Id)
+                .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+                .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
+        }
     }
 }

--- a/Poliedro.Eds.Application/TypeOfCollection/Commands/CreateTypeOfCollection/CreateTypeOfCollectionCommandValidator.cs
+++ b/Poliedro.Eds.Application/TypeOfCollection/Commands/CreateTypeOfCollection/CreateTypeOfCollectionCommandValidator.cs
@@ -1,16 +1,17 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.TypeOfCollection.Commands.CreateTypeOfCollection;
 
 public class CreateTypeOfCollectionCommandValidator : AbstractValidator<CreateTypeOfCollectionRequestDto>
 {
-    //public CreateTypeOfCollectionCommandValidator(ITranslationService translationService)
-    //{
-    //    RuleFor(x => x.Description)
-    //        .NotNull().WithMessage(translationService.GetTranslationByKey("DescriptionNotNull").GetAwaiter().GetResult())
-    //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DescriptionNotEmpty").GetAwaiter().GetResult());
-    //}
+    public CreateTypeOfCollectionCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Description)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotEmpty").GetAwaiter().GetResult());
+    }
 
 
 }

--- a/Poliedro.Eds.Application/TypeOfCollection/Commands/UpdateTypeOfCollection/UpdateTypeOfCollectionCommandValidator.cs
+++ b/Poliedro.Eds.Application/TypeOfCollection/Commands/UpdateTypeOfCollection/UpdateTypeOfCollectionCommandValidator.cs
@@ -1,13 +1,14 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.TypeOfCollection.Commands.UpdateTypeOfCollection;
     public class UpdateTypeOfCollectionCommandValidator : AbstractValidator<UpdateTypeOfCollectionCommand>
     {
-        //public UpdateTypeOfCollectionCommandValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Description)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("DescriptionNotNull").GetAwaiter().GetResult())
-        //        .NotEmpty().WithMessage(translationService.GetTranslationByKey("DescriptionNotEmpty").GetAwaiter().GetResult());
-        //}
+    public UpdateTypeOfCollectionCommandValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Description)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotNull").GetAwaiter().GetResult())
+            .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("DescriptionNotEmpty").GetAwaiter().GetResult());
     }
+}

--- a/Poliedro.Eds.Application/TypeOfCollection/Queries/GetTypeOfCollectionById/GetTypeOfCollectionByIdQueryValidator.cs
+++ b/Poliedro.Eds.Application/TypeOfCollection/Queries/GetTypeOfCollectionById/GetTypeOfCollectionByIdQueryValidator.cs
@@ -1,13 +1,14 @@
 ﻿using FluentValidation;
+using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Application.Ports.Translations;
 
 namespace Poliedro.Eds.Application.TypeOfCollection.Queries.GetTypeOfCollectionById;
     public class GetTypeOfCollectionByIdQueryValidator : AbstractValidator<GetTypeOfCollectionByIdQuery>
     {
-        //public GetTypeOfCollectionByIdQueryValidator(ITranslationService translationService)
-        //{
-        //    RuleFor(x => x.Id)
-        //        .NotNull().WithMessage(translationService.GetTranslationByKey("IdNotNull").GetAwaiter().GetResult())
-        //        .GreaterThan(0).WithMessage(translationService.GetTranslationByKey("IdGreaterThan").GetAwaiter().GetResult());
-        //}
+    public GetTypeOfCollectionByIdQueryValidator(IRedisService redisService)
+    {
+        RuleFor(x => x.Id)
+            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("IdNotNull").GetAwaiter().GetResult())
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdGreaterThan").GetAwaiter().GetResult());
     }
+}


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Switch validation message retrieval from TranslationService to Redis cache across the application’s FluentValidation validators.

Enhancements:
- Replace ITranslationService dependency with IRedisService in all command and query validators
- Fetch validation messages via redisService.GetValueFromCacheAsync instead of translationService.GetTranslationByKey
- Remove commented-out translation logic and add Redis port import in each validator