### PR TITLE
Hu 1188 move validations to handler

### DIFF
--- a/Poliedro.Eds.Api/Common/Extensions/ResultExtension.cs
+++ b/Poliedro.Eds.Api/Common/Extensions/ResultExtension.cs
@@ -7,7 +7,8 @@ public static class ResultExtension
 {
     public static IResult Match<TValue, TError>(
         this Result<TValue, TError> result,
-        Func<TValue, IResult> onSuccess)
+        Func<TValue, IResult> onSuccess,
+        Func<TError, IResult> onFailure= null)
         where TError : Error
     {
         return result.IsSuccess ? onSuccess(result.Value!) : result.ToErrorResult();

--- a/Poliedro.Eds.Api/Controllers/v1/Business/BusinessController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Business/BusinessController.cs
@@ -51,21 +51,15 @@ public class BusinessController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOrIslander")]
     [HttpGet("{id}")]
-    public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetBusinessByIdQuery> validator)
+    public async Task<IResult> GetById([FromRoute] int id)
     {
         var getBusinessQuery = new GetBusinessByIdQuery(Id: id);
-
-        //var validationResult = await validator.ValidateAsync(getBusinessQuery);
-
-        //if (!validationResult.IsValid)
-        //{
-        //    return TypedResults.BadRequest(validationResult.Errors);
-        //}
 
         var result = await mediator.Send(getBusinessQuery);
 
         return result.Match(
-            onSuccess => TypedResults.Ok(result.Value)
+            onSuccess => TypedResults.Ok(result.Value),
+            onFailure => TypedResults.BadRequest(onFailure)
         );
     }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Business/BusinessController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Business/BusinessController.cs
@@ -73,8 +73,7 @@ public class BusinessController(IMediator mediator) : ControllerBase
     [HttpPost]
 
     public async Task<IResult> Create(
-        [FromBody] CreateBusinessCommand createBusinessCommand 
-        )
+        [FromBody] CreateBusinessCommand createBusinessCommand)
     {
         var result = await mediator.Send(createBusinessCommand);
         return result.Match(onSuccess => TypedResults.Created());
@@ -89,14 +88,8 @@ public class BusinessController(IMediator mediator) : ControllerBase
     [Authorize(Policy = "AdminOnly")]
     [HttpPut]
     public async Task<IActionResult> Update(
-    [FromBody] UpdateBusinessCommand updateBusinessCommand
-    )
+    [FromBody] UpdateBusinessCommand updateBusinessCommand)
     {
-        //var validationResult = await validator.ValidateAsync(updateBusinessCommand);
-        //if (!validationResult.IsValid)
-        //{
-        //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-        //}
         var result = await mediator.Send(updateBusinessCommand);
 
         if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/Capacity/CapacityController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Capacity/CapacityController.cs
@@ -39,21 +39,15 @@ public class CapacityController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize]
     [HttpGet("{id}")]
-    public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetCapacityByIdQuery> validator)
+    public async Task<IResult> GetById([FromRoute] int id)
     {
         var getCapacityQuery = new GetCapacityByIdQuery(Id: id);
-
-        var validationResult = await validator.ValidateAsync(getCapacityQuery);
-
-        if (!validationResult.IsValid)
-        {
-            return TypedResults.BadRequest(validationResult.Errors);
-        }
 
         var result = await mediator.Send(getCapacityQuery);
 
         return result.Match(
-            onSuccess => TypedResults.Ok(result.Value)
+            onSuccess => TypedResults.Ok(result.Value),
+            onFailure => TypedResults.BadRequest(onFailure)
         );
     }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Capacity/CapacityController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Capacity/CapacityController.cs
@@ -1,17 +1,16 @@
-﻿using FluentValidation;
-using MediatR;
+﻿using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Poliedro.Eds.Api.Common.Extensions;
-using Poliedro.Eds.Application.Common.Features;
 using Poliedro.Eds.Application.Capacity.Commands.CreateCapacity;
 using Poliedro.Eds.Application.Capacity.Commands.UpdateCapacity;
 using Poliedro.Eds.Application.Capacity.Dtos;
 using Poliedro.Eds.Application.Capacity.Errors;
 using Poliedro.Eds.Application.Capacity.Queries.GellAllCapacity;
 using Poliedro.Eds.Application.Capacity.Queries.GetCapacityById;
+using Poliedro.Eds.Application.Common.Features;
 using Poliedro.Eds.Domain.Common.Pagination;
 using Swashbuckle.AspNetCore.Annotations;
-using Microsoft.AspNetCore.Authorization;
 
 namespace Poliedro.Capacity.Api.Controllers.v1.Capacity;
 
@@ -60,12 +59,8 @@ public class CapacityController(IMediator mediator) : ControllerBase
     [Authorize(Policy = "AdminOnly")]
     [HttpPost]
 
-    public async Task<IResult> Create(
-        [FromBody] CreateCapacityCommand createCapacityCommand,
-        [FromServices] IValidator<CreateCapacityRequestDto> validator)
+    public async Task<IResult> Create([FromBody] CreateCapacityCommand createCapacityCommand)
     {
-        //var validationResult = await validator.ValidateAsync(createCapacityCommand.Request);
-        //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
         var result = await mediator.Send(createCapacityCommand);
         return result.Match(onSuccess => TypedResults.Created());
     }
@@ -78,16 +73,8 @@ public class CapacityController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpPut]
-    public async Task<IActionResult> Update(
-    [FromBody] UpdateCapacityCommand updateCapacityCommand,
-    [FromServices] IValidator<UpdateCapacityCommand> validator)
+    public async Task<IActionResult> Update([FromBody] UpdateCapacityCommand updateCapacityCommand)
     {
-        //var validationResult = await validator.ValidateAsync(updateCapacityCommand);
-        //if (!validationResult.IsValid)
-        //{
-        //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-        //}
-
         var result = await mediator.Send(updateCapacityCommand);
 
         if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/Category/Compartiment.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Category/Compartiment.cs
@@ -1,4 +1,3 @@
-using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -67,13 +66,9 @@ public class CategoryController(IMediator mediator) : ControllerBase
     [Authorize(Policy = "AdminOnly")]
     [HttpPost]
 
-    public async Task<IResult> Create(
-            [FromBody] CreateCategoryCommand createCategoryCommand,
-            [FromServices] IValidator<CreateCategoryRequestDto> validator)
+    public async Task<IResult> Create([FromBody] CreateCategoryCommand createCategoryCommand)
 
     {
-        //var validationResult = await validator.ValidateAsync(createCategoryCommand.Request);
-        //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
         var result = await mediator.Send(createCategoryCommand);
         return result.Match(
              onSuccess => TypedResults.Created()
@@ -88,15 +83,8 @@ public class CategoryController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpPut]
-    public async Task<IActionResult> Update(
- [FromBody] UpdateCategoryCommand updateCategoryCommand,
- [FromServices] IValidator<UpdateCategoryCommand> validator)
+    public async Task<IActionResult> Update([FromBody] UpdateCategoryCommand updateCategoryCommand)
     {
-        //var validationResult = await validator.ValidateAsync(updateCategoryCommand);
-        //if (!validationResult.IsValid)
-        //{
-        //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-        //}
 
         var result = await mediator.Send(updateCategoryCommand);
 

--- a/Poliedro.Eds.Api/Controllers/v1/Category/Compartiment.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Category/Compartiment.cs
@@ -46,21 +46,15 @@ public class CategoryController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpGet("{id}")]
-    public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetCategoryByIdQuery> validator)
+    public async Task<IResult> GetById([FromRoute] int id)
     {
         var getCategoryQuery = new GetCategoryByIdQuery(Id: id);
-
-        //var validationResult = await validator.ValidateAsync(getCategoryQuery);
-
-        //if (!validationResult.IsValid)
-        //{
-        //    return TypedResults.BadRequest(validationResult.Errors);
-        //}
 
         var result = await mediator.Send(getCategoryQuery);
 
         return result.Match(
-            onSuccess => TypedResults.Ok(result.Value)
+            onSuccess => TypedResults.Ok(result.Value),
+            onFailure => TypedResults.BadRequest(onFailure)
         );
     }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Compartiment/Compartiment.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Compartiment/Compartiment.cs
@@ -46,21 +46,16 @@ public class CompartimentController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpGet("{id}")]
-    public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetCompartimentByIdQuery> validator)
+    public async Task<IResult> GetById([FromRoute] int id)
     {
         var getCompartimentQuery = new GetCompartimentByIdQuery(Id: id);
-
-        //var validationResult = await validator.ValidateAsync(getCompartimentQuery);
-
-        //if (!validationResult.IsValid)
-        //{
-        //    return TypedResults.BadRequest(validationResult.Errors);
-        //}
 
         var result = await mediator.Send(getCompartimentQuery);
 
         return result.Match(
-            onSuccess => TypedResults.Ok(result.Value)
+
+            onSuccess => TypedResults.Ok(result.Value),
+            onFailure => TypedResults.BadRequest(onFailure)
         );
     }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Compartiment/Compartiment.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Compartiment/Compartiment.cs
@@ -1,4 +1,3 @@
-using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -68,13 +67,9 @@ public class CompartimentController(IMediator mediator) : ControllerBase
     [Authorize(Policy = "AdminOnly")]
     [HttpPost]
 
-    public async Task<IResult> Create(
-            [FromBody] CreateCompartimentCommand createCompartimentCommand,
-            [FromServices] IValidator<CreateCompartimentRequestDto> validator)
+    public async Task<IResult> Create([FromBody] CreateCompartimentCommand createCompartimentCommand)
 
     {
-        //var validationResult = await validator.ValidateAsync(createCompartimentCommand.Request);
-        //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
         var result = await mediator.Send(createCompartimentCommand);
         return result.Match(
              onSuccess => TypedResults.Created()
@@ -89,16 +84,8 @@ public class CompartimentController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpPut]
-    public async Task<IActionResult> Update(
- [FromBody] UpdateCompartimentCommand updateCompartimentCommand,
- [FromServices] IValidator<UpdateCompartimentCommand> validator)
+    public async Task<IActionResult> Update([FromBody] UpdateCompartimentCommand updateCompartimentCommand)
     {
-        //var validationResult = await validator.ValidateAsync(updateCompartimentCommand);
-        //if (!validationResult.IsValid)
-        //{
-        //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-        //}
-
         var result = await mediator.Send(updateCompartimentCommand);
 
         if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/CompartimentCapacity/CompartimentCapacityController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/CompartimentCapacity/CompartimentCapacityController.cs
@@ -1,5 +1,4 @@
-﻿using FluentValidation;
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Poliedro.Eds.Api.Common.Extensions;
@@ -60,12 +59,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
 
-        public async Task<IResult> Create(
-            [FromBody] CreateCompartimentCapacityCommand createCompartimentCapacityCommand, 
-            [FromServices] IValidator<CreateCompartimentCapacityRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateCompartimentCapacityCommand createCompartimentCapacityCommand)
         {
-            //var validationResult = await validator.ValidateAsync(createCompartimentCapacityCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createCompartimentCapacityCommand);
             return result.Match(onSuccess => TypedResults.Created());
         }
@@ -78,16 +73,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-     [FromBody] UpdateCompartimentCapacityCommand updateCompartimentCapacityCommand,
-     [FromServices] IValidator<UpdateCompartimentCapacityCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateCompartimentCapacityCommand updateCompartimentCapacityCommand)
         {
-        //    var validationResult = await validator.ValidateAsync(updateCompartimentCapacityCommand);
-        //    if (!validationResult.IsValid)
-        //    {
-        //        return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-        //    }
-
             var result = await mediator.Send(updateCompartimentCapacityCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/CompartimentCapacity/CompartimentCapacityController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/CompartimentCapacity/CompartimentCapacityController.cs
@@ -39,21 +39,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetCompartimentCapacityByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getCompartimentCapacityQuery = new GetCompartimentCapacityByIdQuery(Id : id );
-
-            //var validationResult = await validator.ValidateAsync(getCompartimentCapacityQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getCompartimentCapacityQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Court/CourtController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Court/CourtController.cs
@@ -23,21 +23,15 @@ public class CourtController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status200OK, "The operation was successful.", typeof(CourtDto))]
     [Authorize(Policy = "AdminOnly")]
     [HttpGet("{id}")]
-    public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetCourtByIdQuery> validator)
+    public async Task<IResult> GetById([FromRoute] int id)
     {
         var getCourtQuery = new GetCourtByIdQuery(Id: id);
-
-        //var validationResult = await validator.ValidateAsync(getCourtQuery);
-
-        //if (!validationResult.IsValid)
-        //{
-        //    return TypedResults.BadRequest(validationResult.Errors);
-        //}
 
         var result = await mediator.Send(getCourtQuery);
 
         return result.Match(
-            onSuccess => TypedResults.Ok(result.Value)
+            onSuccess => TypedResults.Ok(result.Value),
+            onFailure => TypedResults.BadRequest(onFailure)
         );
     }
 

--- a/Poliedro.Eds.Api/Controllers/v1/CourtDispensersInventory/CourtDispensersInventoryController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/CourtDispensersInventory/CourtDispensersInventoryController.cs
@@ -60,13 +60,9 @@ namespace Poliedro.Eds.Api.Controllers.v1.CourtDispensersInventory
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
 
-        public async Task<IResult> Create(
-            [FromBody] CreateCourtDispensersInventoryCommand createCourtDispensersInventoryCommand,
-            [FromServices] IValidator<CreateCourtDispensersInventoryRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateCourtDispensersInventoryCommand createCourtDispensersInventoryCommand)
 
         {
-            //var validationResult = await validator.ValidateAsync(createCourtDispensersInventoryCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createCourtDispensersInventoryCommand);
             return result.Match(
                  onSuccess => TypedResults.Created()
@@ -81,16 +77,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.CourtDispensersInventory
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-     [FromBody] UpdateCourtDispensersInventoryCommand updateCourtDispensersInventoryCommand,
-     [FromServices] IValidator<UpdateCourtDispensersInventoryCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateCourtDispensersInventoryCommand updateCourtDispensersInventoryCommand)
         {
-            var validationResult = await validator.ValidateAsync(updateCourtDispensersInventoryCommand);
-            if (!validationResult.IsValid)
-            {
-                return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            }
-
             var result = await mediator.Send(updateCourtDispensersInventoryCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/CourtDispensersInventory/CourtDispensersInventoryController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/CourtDispensersInventory/CourtDispensersInventoryController.cs
@@ -39,21 +39,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.CourtDispensersInventory
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetCourtDispensersInventoryByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getCourtDispensersInventoryQuery = new GetCourtDispensersInventoryByIdQuery(Id: id);
-
-            //var validationResult = await validator.ValidateAsync(getCourtDispensersInventoryQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getCourtDispensersInventoryQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/DispenserType/DispenserType.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/DispenserType/DispenserType.cs
@@ -1,10 +1,8 @@
-using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Poliedro.Eds.Api.Common.Extensions;
 using Poliedro.Eds.Application.Common.Features;
-using Poliedro.Eds.Application.Compartiment.Queries.GetCompartimentById;
 using Poliedro.Eds.Application.DispenserType.Commands.CreateDispenserType;
 using Poliedro.Eds.Application.DispenserType.Commands.UpdateDispenserType;
 using Poliedro.Eds.Application.DispenserType.Dtos;
@@ -70,13 +68,9 @@ public class DispenserTypeController(IMediator mediator) : ControllerBase
     [Authorize(Policy = "AdminOnly")]
     [HttpPost]
 
-    public async Task<IResult> Create(
-            [FromBody] CreateDispenserTypeCommand createDispenserTypeCommand,
-            [FromServices] IValidator<CreateDispenserTypeRequestDto> validator)
+    public async Task<IResult> Create([FromBody] CreateDispenserTypeCommand createDispenserTypeCommand)
 
     {
-            //var validationResult = await validator.ValidateAsync(createDispenserTypeCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
         var result = await mediator.Send(createDispenserTypeCommand);
             return result.Match(
                  onSuccess => TypedResults.Created()
@@ -91,9 +85,7 @@ public class DispenserTypeController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpPut]
-    public async Task<IActionResult> Update(
- [FromBody] UpdateDispenserTypeCommand updateDispenserTypeCommand,
- [FromServices] IValidator<UpdateDispenserTypeCommand> validator)
+    public async Task<IActionResult> Update([FromBody] UpdateDispenserTypeCommand updateDispenserTypeCommand
     {
 
         var result = await mediator.Send(updateDispenserTypeCommand);

--- a/Poliedro.Eds.Api/Controllers/v1/DispenserType/DispenserType.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/DispenserType/DispenserType.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Poliedro.Eds.Api.Common.Extensions;
 using Poliedro.Eds.Application.Common.Features;
+using Poliedro.Eds.Application.Compartiment.Queries.GetCompartimentById;
 using Poliedro.Eds.Application.DispenserType.Commands.CreateDispenserType;
 using Poliedro.Eds.Application.DispenserType.Commands.UpdateDispenserType;
 using Poliedro.Eds.Application.DispenserType.Dtos;
@@ -47,17 +48,20 @@ public class DispenserTypeController(IMediator mediator) : ControllerBase
     [Authorize(Policy = "AdminOnly")]
     [HttpGet("{id}")]
 
-    public async Task<IResult> GetById(int id)
+    public async Task<IResult> GetById([FromRoute] int id)
     {
-        var result = await mediator.Send(new GetDispenserTypeByIdQuery(id));
+        var getDyspenserTypeQuery = new GetDispenserTypeByIdQuery(Id: id);
 
-        if (result.IsSuccess)
-            return TypedResults.Ok(result.Value);
+        var result = await mediator.Send(getDyspenserTypeQuery);
 
-        return TypedResults.NotFound("DispenserType no encontrado.");
+        return result.Match(
+
+            onSuccess => TypedResults.Ok(result.Value),
+            onFailure => TypedResults.BadRequest(onFailure)
+        );
     }
 
-    [SwaggerOperation(
+        [SwaggerOperation(
         Summary = "Create new DispenserType")]
     [SwaggerResponse(StatusCodes.Status204NoContent, "The operation was successful.")]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Incorrect request parameters.", typeof(ProblemDetails))]

--- a/Poliedro.Eds.Api/Controllers/v1/DispenserType/DispenserType.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/DispenserType/DispenserType.cs
@@ -85,7 +85,7 @@ public class DispenserTypeController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpPut]
-    public async Task<IActionResult> Update([FromBody] UpdateDispenserTypeCommand updateDispenserTypeCommand
+    public async Task<IActionResult> Update([FromBody] UpdateDispenserTypeCommand updateDispenserTypeCommand)
     {
 
         var result = await mediator.Send(updateDispenserTypeCommand);

--- a/Poliedro.Eds.Api/Controllers/v1/Dispensers/DipensersController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Dispensers/DipensersController.cs
@@ -10,7 +10,6 @@ using Poliedro.Eds.Application.Dispensers.Dtos;
 using Poliedro.Eds.Application.Dispensers.Errors;
 using Poliedro.Eds.Application.Dispensers.Queries.GellAllDispensers;
 using Poliedro.Eds.Application.Dispensers.Queries.GetDispensersById;
-using Poliedro.Eds.Application.DispenserType.Queries.GetDispenserTypeById;
 using Poliedro.Eds.Domain.Common.Pagination;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -48,14 +47,17 @@ public class DispensersController(IMediator mediator) : ControllerBase
     [Authorize(Policy = "AdminOnly")]
     [HttpGet("{id}")]
 
-    public async Task<IResult> GetById(int id)
+    public async Task<IResult> GetById([FromRoute] int id)
     {
-        var result = await mediator.Send(new GetDispensersByIdQuery(id));
+        var getDyspenserQuery = new GetDispensersByIdQuery(Id: id);
 
-        if (result.IsSuccess)
-            return TypedResults.Ok(result.Value);
+        var result = await mediator.Send(getDyspenserQuery);
 
-        return TypedResults.NotFound("Dispenser no encontrado.");
+        return result.Match(
+
+            onSuccess => TypedResults.Ok(result.Value),
+            onFailure => TypedResults.BadRequest(onFailure)
+        );
     }
 
     [SwaggerOperation(

--- a/Poliedro.Eds.Api/Controllers/v1/Dispensers/DipensersController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Dispensers/DipensersController.cs
@@ -69,13 +69,9 @@ public class DispensersController(IMediator mediator) : ControllerBase
     [Authorize(Policy = "AdminOnly")]
     [HttpPost]
 
-    public async Task<IResult> Create(
-            [FromBody] CreateDispensersCommand createDispensersCommand,
-            [FromServices] IValidator<CreateDispensersRequestDto> validator)
+    public async Task<IResult> Create([FromBody] CreateDispensersCommand createDispensersCommand)
 
     {
-            //var validationResult = await validator.ValidateAsync(createDispensersCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
         var result = await mediator.Send(createDispensersCommand);
             return result.Match(
                  onSuccess => TypedResults.Created()

--- a/Poliedro.Eds.Api/Controllers/v1/Eds/EdsController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Eds/EdsController.cs
@@ -39,21 +39,15 @@ public class EdsController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOrIslander")]
     [HttpGet("{id}")]
-    public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetEdsByIdQuery> validator)
+    public async Task<IResult> GetById([FromRoute] int id)
     {
         var getEdsQuery = new GetEdsByIdQuery(Id: id);
-
-        //var validationResult = await validator.ValidateAsync(getEdsQuery);
-
-        //if (!validationResult.IsValid)
-        //{
-        //    return TypedResults.BadRequest(validationResult.Errors);
-        //}
 
         var result = await mediator.Send(getEdsQuery);
 
         return result.Match(
-            onSuccess => TypedResults.Ok(result.Value)
+            onSuccess => TypedResults.Ok(result.Value),
+            onFailure => TypedResults.BadRequest(onFailure)
         );
     }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Eds/EdsController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Eds/EdsController.cs
@@ -60,12 +60,8 @@ public class EdsController(IMediator mediator) : ControllerBase
     [Authorize(Policy = "AdminOrIslander")]
     [HttpPost]
 
-    public async Task<IResult> Create(
-            [FromBody] CreateEdsCommand createEdsCommand,
-            [FromServices] IValidator<CreateEdsRequestDto> validator)
+    public async Task<IResult> Create([FromBody] CreateEdsCommand createEdsCommand)
     {
-        //var validationResult = await validator.ValidateAsync(createEdsCommand.Request);
-        //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
         var result = await mediator.Send(createEdsCommand);
         return result.Match(onSuccess => TypedResults.Created());
     }
@@ -78,15 +74,8 @@ public class EdsController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpPut]
-    public async Task<IActionResult> Update(
-    [FromBody] UpdateEdsCommand updateEdsCommand,
-    [FromServices] IValidator<UpdateEdsCommand> validator)
+    public async Task<IActionResult> Update([FromBody] UpdateEdsCommand updateEdsCommand)
     {
-        //var validationResult = await validator.ValidateAsync(updateEdsCommand);
-        //if (!validationResult.IsValid)
-        //{
-        //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-        //}
 
         var result = await mediator.Send(updateEdsCommand);
 

--- a/Poliedro.Eds.Api/Controllers/v1/EdsTank/EdsTankController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/EdsTank/EdsTankController.cs
@@ -60,12 +60,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender;
     [Authorize(Policy = "AdminOnly")]
     [HttpPost]
 
-        public async Task<IResult> Create(
-            [FromBody] CreateEdsTankCommand createEdsTankCommand, 
-            [FromServices] IValidator<CreateEdsTankRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateEdsTankCommand createEdsTankCommand)
         {
-            //var validationResult = await validator.ValidateAsync(createEdsTankCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createEdsTankCommand);
             return result.Match(onSuccess => TypedResults.Created());
         }
@@ -78,15 +74,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender;
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpPut]
-        public async Task<IActionResult> Update(
-        [FromBody] UpdateEdsTankCommand updateEdsTankCommand,
-        [FromServices] IValidator<UpdateEdsTankCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateEdsTankCommand updateEdsTankCommand)
         {
-            //var validationResult = await validator.ValidateAsync(updateEdsTankCommand);
-            //if (!validationResult.IsValid)
-            //{
-            //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            //}
 
             var result = await mediator.Send(updateEdsTankCommand);
 

--- a/Poliedro.Eds.Api/Controllers/v1/EdsTank/EdsTankController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/EdsTank/EdsTankController.cs
@@ -39,21 +39,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender;
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetEdsTankByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getEdsTankQuery = new GetEdsTankByIdQuery(Id : id );
-
-            //var validationResult = await validator.ValidateAsync(getEdsTankQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getEdsTankQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Expenditures/ExpendituresController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Expenditures/ExpendituresController.cs
@@ -39,21 +39,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOrIslander")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetExpendituresByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getExpendituresQuery = new GetExpendituresByIdQuery(Id : id );
-
-            //var validationResult = await validator.ValidateAsync(getExpendituresQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getExpendituresQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Hose/HoseController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Hose/HoseController.cs
@@ -1,5 +1,4 @@
-﻿using FluentValidation;
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Poliedro.Eds.Api.Common.Extensions;
@@ -61,14 +60,9 @@ namespace Poliedro.Eds.Api.Controllers.v1.Hose
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOrIslander")]
         [HttpGet("last-accumulated")]
-        public async Task<IActionResult> GetLastAccumulated(
-            [FromQuery] int idDispenser,
-            [FromQuery] int idHose,
-            [FromServices] IValidator<GetLastAccumulatedQuery> validator)
+        public async Task<IActionResult> GetLastAccumulated([FromQuery] int idDispenser,[FromQuery] int idHose)
         {
             var getLastAccumulatedQuery = new GetLastAccumulatedQuery(idDispenser, idHose);
-            //var validationResult = await validator.ValidateAsync(getLastAccumulatedQuery);
-            //if (!validationResult.IsValid) return BadRequest(validationResult.Errors);
             var result = await mediator.Send(getLastAccumulatedQuery);
             if (!result.IsSuccess) return StatusCode((int)result.Error.HttpStatusCode, result.Error);
             return Ok(result.Value);
@@ -83,13 +77,9 @@ namespace Poliedro.Eds.Api.Controllers.v1.Hose
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
 
-        public async Task<IResult> Create(
-            [FromBody] CreateHoseCommand createHoseCommand,
-            [FromServices] IValidator<CreateHoseRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateHoseCommand createHoseCommand)
 
         {
-            //var validationResult = await validator.ValidateAsync(createHoseCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createHoseCommand);
             return result.Match(
                  onSuccess => TypedResults.Created()
@@ -104,15 +94,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Hose
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-     [FromBody] UpdateHoseCommand updateHoseCommand,
-     [FromServices] IValidator<UpdateHoseCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateHoseCommand updateHoseCommand)
         {
-            //var validationResult = await validator.ValidateAsync(updateHoseCommand);
-            //if (!validationResult.IsValid)
-            //{
-            //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            //}
 
             var result = await mediator.Send(updateHoseCommand);
 

--- a/Poliedro.Eds.Api/Controllers/v1/Hose/HoseController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Hose/HoseController.cs
@@ -41,21 +41,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Hose
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetHoseByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getHoseQuery = new GetHoseByIdQuery(Id: id);
-
-            //var validationResult = await validator.ValidateAsync(getHoseQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getHoseQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/HoseHistory/HoseHistoryController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/HoseHistory/HoseHistoryController.cs
@@ -60,12 +60,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.HoseHistory
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
 
-        public async Task<IResult> Create(
-            [FromBody] CreateHoseHistoryCommand createHoseHistoryCommand,
-            [FromServices] IValidator<CreateHoseHistoryRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateHoseHistoryCommand createHoseHistoryCommand)
         {
-            //var validationResult = await validator.ValidateAsync(createHoseHistoryCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createHoseHistoryCommand);
             return result.Match(
                  onSuccess => TypedResults.Created()
@@ -80,16 +76,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.HoseHistory
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-     [FromBody] UpdateHoseHistoryCommand updateHoseHistoryCommand,
-     [FromServices] IValidator<UpdateHoseHistoryCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateHoseHistoryCommand updateHoseHistoryCommand)
         {
-            var validationResult = await validator.ValidateAsync(updateHoseHistoryCommand);
-            if (!validationResult.IsValid)
-            {
-                return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            }
-
             var result = await mediator.Send(updateHoseHistoryCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/HoseHistory/HoseHistoryController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/HoseHistory/HoseHistoryController.cs
@@ -39,21 +39,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.HoseHistory
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetHoseHistoryByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getHoseHistoryQuery = new GetHoseHistoryByIdQuery(Id: id);
-
-            //var validationResult = await validator.ValidateAsync(getHoseHistoryQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getHoseHistoryQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Island/IslandController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Island/IslandController.cs
@@ -40,21 +40,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Island
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetIslandByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getIslandQuery = new GetIslandByIdQuery(Id: id);
-
-            //var validationResult = await validator.ValidateAsync(getIslandQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getIslandQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Island/IslandController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Island/IslandController.cs
@@ -60,13 +60,9 @@ namespace Poliedro.Eds.Api.Controllers.v1.Island
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
-        public async Task<IResult> Create(
-           [FromBody] CreateIslandCommand createIslandCommand,
-           [FromServices] IValidator<CreateIslandRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateIslandCommand createIslandCommand)
 
         {
-            //var validationResult = await validator.ValidateAsync(createIslandCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createIslandCommand);
             return result.Match(
                  onSuccess => TypedResults.Created()
@@ -81,16 +77,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Island
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-     [FromBody] UpdateIslandCommand updateIslandCommand,
-     [FromServices] IValidator<UpdateIslandCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateIslandCommand updateIslandCommand)
         {
-            var validationResult = await validator.ValidateAsync(updateIslandCommand);
-            if (!validationResult.IsValid)
-            {
-                return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            }
-
             var result = await mediator.Send(updateIslandCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/Islander/IslanderController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Islander/IslanderController.cs
@@ -62,19 +62,14 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [Authorize(Policy = "AdminOrIslander")]
         [HttpPost]
 
-        public async Task<IResult> Create(
-           [FromBody] CreateIslanderCommand createIslanderCommand)
+        public async Task<IResult> Create([FromBody] CreateIslanderCommand createIslanderCommand)
 
         {
-
             var nameClaimToken = HttpContext.User.FindFirst("name")?.Value;
 
             var command = new CreateIslanderCommand(createIslanderCommand.Request, nameClaimToken);
 
             Console.WriteLine($"nombre del token: {nameClaimToken}");
-
-            //var validationResult = await validator.ValidateAsync(createIslanderCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
 
             var result = await mediator.Send(command);
             return result.Match(
@@ -90,16 +85,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-     [FromBody] UpdateIslanderCommand updateIslanderCommand,
-     [FromServices] IValidator<UpdateIslanderCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateIslanderCommand updateIslanderCommand)
         {
-            var validationResult = await validator.ValidateAsync(updateIslanderCommand);
-            if (!validationResult.IsValid)
-            {
-                return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            }
-
             var result = await mediator.Send(updateIslanderCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/Islander/IslanderController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Islander/IslanderController.cs
@@ -41,21 +41,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOrIslander")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetIslanderByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getIslanderQuery = new GetIslanderByIdQuery(Id: id);
-
-            //var validationResult = await validator.ValidateAsync(getIslanderQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getIslanderQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Product/ProductController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Product/ProductController.cs
@@ -1,5 +1,4 @@
-﻿using FluentValidation;
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Poliedro.Eds.Api.Common.Extensions;
@@ -60,12 +59,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
 
-        public async Task<IResult> Create(
-            [FromBody] CreateProductCommand createProductCommand, 
-            [FromServices] IValidator<CreateProductRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateProductCommand createProductCommand)
         {
-            //var validationResult = await validator.ValidateAsync(createProductCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createProductCommand);
             return result.Match(onSuccess => TypedResults.Created());
         }
@@ -78,16 +73,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-     [FromBody] UpdateProductCommand updateProductCommand,
-     [FromServices] IValidator<UpdateProductCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateProductCommand updateProductCommand)
         {
-            var validationResult = await validator.ValidateAsync(updateProductCommand);
-            if (!validationResult.IsValid)
-            {
-                return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            }
-
             var result = await mediator.Send(updateProductCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/Product/ProductController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Product/ProductController.cs
@@ -39,21 +39,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetProductByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getProductQuery = new GetProductByIdQuery(Id : id );
-
-            //var validationResult = await validator.ValidateAsync(getProductQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getProductQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/ProductCompartiment/ProductCompartimentController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/ProductCompartiment/ProductCompartimentController.cs
@@ -39,21 +39,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetProductCompartimentByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getProductCompartimentQuery = new GetProductCompartimentByIdQuery(Id : id );
-
-            //var validationResult = await validator.ValidateAsync(getProductCompartimentQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getProductCompartimentQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/ProductCompartiment/ProductCompartimentController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/ProductCompartiment/ProductCompartimentController.cs
@@ -60,12 +60,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
 
-        public async Task<IResult> Create(
-            [FromBody] CreateProductCompartimentCommand createProductCompartimentCommand, 
-            [FromServices] IValidator<CreateProductCompartimentRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateProductCompartimentCommand createProductCompartimentCommand)
         {
-            var validationResult = await validator.ValidateAsync(createProductCompartimentCommand.Request);
-            if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createProductCompartimentCommand);
             return result.Match(onSuccess => TypedResults.Created());
         }
@@ -78,16 +74,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-     [FromBody] UpdateProductCompartimentCommand updateProductCompartimentCommand,
-     [FromServices] IValidator<UpdateProductCompartimentCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateProductCompartimentCommand updateProductCompartimentCommand)
         {
-            var validationResult = await validator.ValidateAsync(updateProductCompartimentCommand);
-            if (!validationResult.IsValid)
-            {
-                return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            }
-
             var result = await mediator.Send(updateProductCompartimentCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/ProductType/ProductTypeController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/ProductType/ProductTypeController.cs
@@ -60,12 +60,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
 
-        public async Task<IResult> Create(
-            [FromBody] CreateProductTypeCommand createProductTypeCommand, 
-            [FromServices] IValidator<CreateProductTypeRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateProductTypeCommand createProductTypeCommand)
         {
-            //var validationResult = await validator.ValidateAsync(createProductTypeCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createProductTypeCommand);
             return result.Match(onSuccess => TypedResults.Created());
         }
@@ -78,16 +74,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-     [FromBody] UpdateProductTypeCommand updateProductTypeCommand,
-     [FromServices] IValidator<UpdateProductTypeCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateProductTypeCommand updateProductTypeCommand)
         {
-            //var validationResult = await validator.ValidateAsync(updateProductTypeCommand);
-            //if (!validationResult.IsValid)
-            //{
-            //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            //}
-
             var result = await mediator.Send(updateProductTypeCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/ProductType/ProductTypeController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/ProductType/ProductTypeController.cs
@@ -39,21 +39,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetProductTypeByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getProductTypeQuery = new GetProductTypeByIdQuery(Id : id );
-
-            //var validationResult = await validator.ValidateAsync(getProductTypeQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getProductTypeQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Provider/ProviderController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Provider/ProviderController.cs
@@ -40,21 +40,15 @@ public class ProviderController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpGet("{id}")]
-    public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetProviderByIdQuery> validator)
+    public async Task<IResult> GetById([FromRoute] int id)
     {
         var getProviderQuery = new GetProviderByIdQuery(Id: id);
-
-        //var validationResult = await validator.ValidateAsync(getProviderQuery);
-
-        //if (!validationResult.IsValid)
-        //{
-        //    return TypedResults.BadRequest(validationResult.Errors);
-        //}
 
         var result = await mediator.Send(getProviderQuery);
 
         return result.Match(
-            onSuccess => TypedResults.Ok(result.Value)
+            onSuccess => TypedResults.Ok(result.Value),
+            onFailure => TypedResults.BadRequest(onFailure)
         );
     }
 

--- a/Poliedro.Eds.Api/Controllers/v1/Provider/ProviderController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Provider/ProviderController.cs
@@ -61,12 +61,8 @@ public class ProviderController(IMediator mediator) : ControllerBase
     [Authorize(Policy = "AdminOnly")]
     [HttpPost]
 
-    public async Task<IResult> Create(
-        [FromBody] CreateProviderCommand createProviderCommand,
-        [FromServices] IValidator<CreateProviderRequestDto> validator)
+    public async Task<IResult> Create([FromBody] CreateProviderCommand createProviderCommand)
     {
-        //var validationResult = await validator.ValidateAsync(createProviderCommand.Request);
-        //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
         var result = await mediator.Send(createProviderCommand);
         return result.Match(onSuccess => TypedResults.Created());
     }
@@ -79,16 +75,8 @@ public class ProviderController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpPut]
-    public async Task<IActionResult> Update(
-    [FromBody] UpdateProviderCommand updateProviderCommand,
-    [FromServices] IValidator<UpdateProviderCommand> validator)
+    public async Task<IActionResult> Update([FromBody] UpdateProviderCommand updateProviderCommand)
     {
-        //var validationResult = await validator.ValidateAsync(updateProviderCommand);
-        //if (!validationResult.IsValid)
-        //{
-        //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-        //}
-
         var result = await mediator.Send(updateProviderCommand);
 
         if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/Shopping/ShoppingController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Shopping/ShoppingController.cs
@@ -67,12 +67,9 @@ namespace Poliedro.Eds.Api.Controllers.v1.Shopping
         [HttpPost]
 
         public async Task<IResult> Create(
-            [FromBody] CreateShoppingCommand createShoppingCommand,
-            [FromServices] IValidator<CreateShoppingRequestDto> validator)
+            [FromBody] CreateShoppingCommand createShoppingCommand)
 
         {
-            //var validationResult = await validator.ValidateAsync(createShoppingCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createShoppingCommand);
             return result.Match(
                  onSuccess => TypedResults.Created()
@@ -87,16 +84,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Shopping
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-        [FromBody] UpdateShoppingCommand updateShoppingCommand,
-        [FromServices] IValidator<UpdateShoppingCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateShoppingCommand updateShoppingCommand)
         {
-            //var validationResult = await validator.ValidateAsync(updateShoppingCommand);
-            //if (!validationResult.IsValid)
-            //{
-            //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            //}
-
             var result = await mediator.Send(updateShoppingCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/Shopping/ShoppingController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Shopping/ShoppingController.cs
@@ -46,16 +46,9 @@ namespace Poliedro.Eds.Api.Controllers.v1.Shopping
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetShoppingByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getShoppingQuery = new GetShoppingByIdQuery(Id: id);
-
-            //var validationResult = await validator.ValidateAsync(getShoppingQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getShoppingQuery);
 

--- a/Poliedro.Eds.Api/Controllers/v1/ShoppingProduct/ShoppingProductController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/ShoppingProduct/ShoppingProductController.cs
@@ -1,4 +1,3 @@
-using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -67,19 +66,9 @@ namespace Poliedro.Eds.Api.Controllers.v1.ShoppingProduct
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
 
-        public async Task<IResult> Create(
-            [FromBody] CreateShoppingProductCommand createShoppingProductCommand,
-            [FromServices] IValidator<CreateShoppingProductRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateShoppingProductCommand createShoppingProductCommand)
 
         {
-
-            var validationResult = await validator.ValidateAsync(createShoppingProductCommand.Request);
-            if (!validationResult.IsValid)
-            {
-                var mensajes = validationResult.Errors.Select(e => e.ErrorMessage).ToList();
-                return TypedResults.BadRequest(mensajes);
-            }
-
             var result = await mediator.Send(createShoppingProductCommand);
             return result.Match(
                  onSuccess => TypedResults.Created()
@@ -94,16 +83,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.ShoppingProduct
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-        [FromBody] UpdateShoppingProductCommand updateShoppingProductCommand,
-        [FromServices] IValidator<UpdateShoppingProductCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateShoppingProductCommand updateShoppingProductCommand)
         {
-            var validationResult = await validator.ValidateAsync(updateShoppingProductCommand);
-            if (!validationResult.IsValid)
-            {
-                return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            }
-
             var result = await mediator.Send(updateShoppingProductCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/ShoppingProduct/ShoppingProductController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/ShoppingProduct/ShoppingProductController.cs
@@ -46,21 +46,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.ShoppingProduct
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetShoppingProductByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getShoppingProductQuery = new GetShoppingProductByIdQuery(Id: id);
-
-            //var validationResult = await validator.ValidateAsync(getShoppingProductQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getShoppingProductQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/ShoppingProductInventory/ShoppingProductInventoryController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/ShoppingProductInventory/ShoppingProductInventoryController.cs
@@ -65,21 +65,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.ShoppingProductInventory
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetShopingProductInventoryByIdShopping([FromRoute] int id, [FromServices] IValidator<GetShoppingProductInventoryByIdQuery> validator)
+        public async Task<IResult> GetShopingProductInventoryByIdShopping([FromRoute] int id)
         {
             var getShoppingProductQuery = new GetShoppingProductInventoryByIdQuery(Id: id);
-
-            //var validationResult = await validator.ValidateAsync(getShoppingProductQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getShoppingProductQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/ShoppingProductInventory/ShoppingProductInventoryController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/ShoppingProductInventory/ShoppingProductInventoryController.cs
@@ -44,18 +44,13 @@ namespace Poliedro.Eds.Api.Controllers.v1.ShoppingProductInventory
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
-        public async Task<IResult> Create([FromBody] CreateShoppingProductInventoryCommand createShoppingProductInventoryCommand,
-            [FromServices] IValidator<CreateShoppingProductInventoryRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateShoppingProductInventoryCommand createShoppingProductInventoryCommand)
         {
-            //var validationResult = await validator.ValidateAsync(createShoppingProductInventoryCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createShoppingProductInventoryCommand);
             return result.Match(
                  onSuccess => TypedResults.Created()
              );
         }
-
-
 
         [SwaggerOperation(Summary = "Get ShoppingProductInventory")]
         [SwaggerResponse(StatusCodes.Status200OK, "The operation was successful.", typeof(ShoppingProductDto))]

--- a/Poliedro.Eds.Api/Controllers/v1/Tank/TankController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Tank/TankController.cs
@@ -60,13 +60,9 @@ namespace Poliedro.Eds.Api.Controllers.v1.Tank
         [Authorize(Policy = "AdminOnly")]
         [HttpPost]
 
-        public async Task<IResult> Create(
-           [FromBody] CreateTankCommand createTankCommand,
-           [FromServices] IValidator<CreateTankRequestDto> validator)
+        public async Task<IResult> Create([FromBody] CreateTankCommand createTankCommand)
 
         {
-            //var validationResult = await validator.ValidateAsync(createTankCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createTankCommand);
             return result.Match(
                  onSuccess => TypedResults.Created()
@@ -81,16 +77,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Tank
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-        [FromBody] UpdateTankCommand updateTankCommand,
-        [FromServices] IValidator<UpdateTankCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateTankCommand updateTankCommand)
         {
-            var validationResult = await validator.ValidateAsync(updateTankCommand);
-            if (!validationResult.IsValid)
-            {
-                return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            }
-
             var result = await mediator.Send(updateTankCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Api/Controllers/v1/Tank/TankController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Tank/TankController.cs
@@ -39,21 +39,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Tank
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetTankByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getTankQuery = new GetTankByIdQuery(Id: id);
-
-            //var validationResult = await validator.ValidateAsync(getTankQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getTankQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/TypeOfCollection/TypeOfCollectionController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/TypeOfCollection/TypeOfCollectionController.cs
@@ -39,21 +39,15 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOrIslander")]
         [HttpGet("{id}")]
-        public async Task<IResult> GetById([FromRoute] int id, [FromServices] IValidator<GetTypeOfCollectionByIdQuery> validator)
+        public async Task<IResult> GetById([FromRoute] int id)
         {
             var getTypeOfCollectionQuery = new GetTypeOfCollectionByIdQuery(Id : id );
-
-            //var validationResult = await validator.ValidateAsync(getTypeOfCollectionQuery);
-
-            //if (!validationResult.IsValid)
-            //{
-            //    return TypedResults.BadRequest(validationResult.Errors);
-            //}
 
             var result = await mediator.Send(getTypeOfCollectionQuery);
 
             return result.Match(
-                onSuccess => TypedResults.Ok(result.Value)
+                onSuccess => TypedResults.Ok(result.Value),
+                onFailure => TypedResults.BadRequest(onFailure)
             );
         }
 

--- a/Poliedro.Eds.Api/Controllers/v1/TypeOfCollection/TypeOfCollectionController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/TypeOfCollection/TypeOfCollectionController.cs
@@ -61,11 +61,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [HttpPost]
 
         public async Task<IResult> Create(
-            [FromBody] CreateTypeOfCollectionCommand createTypeOfCollectionCommand, 
-            [FromServices] IValidator<CreateTypeOfCollectionRequestDto> validator)
+            [FromBody] CreateTypeOfCollectionCommand createTypeOfCollectionCommand)
         {
-            //var validationResult = await validator.ValidateAsync(createTypeOfCollectionCommand.Request);
-            //if (!validationResult.IsValid) return TypedResults.BadRequest(validationResult.Errors);
             var result = await mediator.Send(createTypeOfCollectionCommand);
             return result.Match(onSuccess => TypedResults.Created());
         }
@@ -78,16 +75,8 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
         [Authorize(Policy = "AdminOnly")]
         [HttpPut]
-        public async Task<IActionResult> Update(
-     [FromBody] UpdateTypeOfCollectionCommand updateTypeOfCollectionCommand,
-     [FromServices] IValidator<UpdateTypeOfCollectionCommand> validator)
+        public async Task<IActionResult> Update([FromBody] UpdateTypeOfCollectionCommand updateTypeOfCollectionCommand)
         {
-            //var validationResult = await validator.ValidateAsync(updateTypeOfCollectionCommand);
-            //if (!validationResult.IsValid)
-            //{
-            //    return BadRequest(ResponseApiService.Response(StatusCodes.Status400BadRequest, validationResult.Errors));
-            //}
-
             var result = await mediator.Send(updateTypeOfCollectionCommand);
 
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Application/Business/Commands/CreateBusiness/CreateBusinessCommandHandler.cs
+++ b/Poliedro.Eds.Application/Business/Commands/CreateBusiness/CreateBusinessCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Business.Helpers;
 using Poliedro.Eds.Application.Ports.Redis;
@@ -6,16 +7,22 @@ using Poliedro.Eds.Domain.Business.DomaianServices.Create;
 using Poliedro.Eds.Domain.Business.Entities;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Business.Commands.CreateBusiness;
 
 public class CreateBusinessCommandHandler(
     IBusinessCreateDomianService businessCreateDomianService,
-    IMapper mapper, 
+    IMapper mapper,
+    IValidator<CreateBusinessRequestDto> validator,
     IRedisService redisService) : IRequestHandler<CreateBusinessCommand, Result<VoidResult, Error>>
 {
     public async Task<Result<VoidResult, Error>> Handle(CreateBusinessCommand request, CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request.Request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
         var result = await businessCreateDomianService.CreateAsync(mapper.Map<BusinessEntity>(request.Request));
         await RedisHelper.RemoveBusinessCacheIfSuccessAsync(result, redisService);

--- a/Poliedro.Eds.Application/Business/Commands/UpdateBusiness/UpdateBusinessCommandHandler.cs
+++ b/Poliedro.Eds.Application/Business/Commands/UpdateBusiness/UpdateBusinessCommandHandler.cs
@@ -1,17 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Business.DomainBusiness;
 using Poliedro.Eds.Domain.Business.Entities;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Business.Commands.UpdateBusiness;
 
-public class UpdateBusinessCommandHandler(IBusinessUpdateService BusinessUpdateService, IMapper mapper) : IRequestHandler<UpdateBusinessCommand, Result<VoidResult, Error>>
+public class UpdateBusinessCommandHandler(
+    IBusinessUpdateService BusinessUpdateService,
+    IMapper mapper,
+    IValidator<UpdateBusinessCommand> validator
+    ) : IRequestHandler<UpdateBusinessCommand, Result<VoidResult, Error>>
 {
-    public async Task<Result<VoidResult, Error>> Handle(UpdateBusinessCommand request,
-        CancellationToken cancellationToken)
+    public async Task<Result<VoidResult, Error>> Handle(UpdateBusinessCommand request,CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
         var BusinessEntity = mapper.Map<BusinessEntity>(request);
         var result = await BusinessUpdateService.UpdateAsync(BusinessEntity);
 

--- a/Poliedro.Eds.Application/Business/Queries/GetBusinessById/GetBusinessByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Business/Queries/GetBusinessById/GetBusinessByIdQueryHandler.cs
@@ -4,16 +4,26 @@ using Poliedro.Eds.Application.Business.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Business.DomainBusiness;
+using FluentValidation;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Business.Queries.GetBusinessById;
 
 public class GetBusinessByIdQueryHandler(
     IBusinessGetByIdService BusinessGetByIdService,
-    IMapper mapper)
+    IMapper mapper,
+    IValidator<GetBusinessByIdQuery> validator)
     : IRequestHandler<GetBusinessByIdQuery, Result<BusinessDto, Error>>
 {
     public async Task<Result<BusinessDto, Error>> Handle(GetBusinessByIdQuery request, CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+        {
+            return Result<BusinessDto, Error>.Failure(
+            Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+        }
+
         var result = await BusinessGetByIdService.GetByIdAsync(request.Id);
         if (!result.IsSuccess)
             return result.Error!;

--- a/Poliedro.Eds.Application/Capacity/Commands/CreateCapacity/CreateCapacityCommandHandler.cs
+++ b/Poliedro.Eds.Application/Capacity/Commands/CreateCapacity/CreateCapacityCommandHandler.cs
@@ -1,18 +1,26 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
-using Poliedro.Eds.Domain.Common.Results;
-using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Capacity.DomainCapacity;
 using Poliedro.Eds.Domain.Capacity.Entities;
+using Poliedro.Eds.Domain.Common.Results;
+using Poliedro.Eds.Domain.Common.Results.Errors;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Capacity.Commands.CreateCapacity;
 
 public class CreateCapacityCommandHandler(
     ICapacityCreateService CapacityCreateService,
-    IMapper mapper) : IRequestHandler<CreateCapacityCommand, Result<VoidResult, Error>>
+    IMapper mapper,
+    IValidator<CreateCapacityRequestDto> validator) : IRequestHandler<CreateCapacityCommand, Result<VoidResult, Error>>
 {
     public async Task<Result<VoidResult, Error>> Handle(CreateCapacityCommand request, CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request.Request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
         var CapacityEntity = mapper.Map<CapacityEntity>(request.Request);
         var result = await CapacityCreateService.CreateAsync(CapacityEntity);
         if (!result.IsSuccess)

--- a/Poliedro.Eds.Application/Capacity/Commands/UpdateCapacity/UpdateCapacityCommandHandler.cs
+++ b/Poliedro.Eds.Application/Capacity/Commands/UpdateCapacity/UpdateCapacityCommandHandler.cs
@@ -1,17 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Capacity.DomainCapacity;
 using Poliedro.Eds.Domain.Capacity.Entities;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Capacity.Commands.UpdateCapacity;
 
-public class UpdateCapacityCommandHandler(ICapacityUpdateService CapacityUpdateService, IMapper mapper) : IRequestHandler<UpdateCapacityCommand, Result<VoidResult, Error>>
+public class UpdateCapacityCommandHandler(
+    ICapacityUpdateService CapacityUpdateService,
+    IMapper mapper,
+    IValidator<UpdateCapacityCommand> validator
+    ) : IRequestHandler<UpdateCapacityCommand, Result<VoidResult, Error>>
 {
-    public async Task<Result<VoidResult, Error>> Handle(UpdateCapacityCommand request,
-        CancellationToken cancellationToken)
+    public async Task<Result<VoidResult, Error>> Handle(UpdateCapacityCommand request,CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
         var CapacityEntity = mapper.Map<CapacityEntity>(request);
         var result = await CapacityUpdateService.UpdateAsync(CapacityEntity);
 

--- a/Poliedro.Eds.Application/Capacity/Queries/GetCapacityById/GetCapacityByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Capacity/Queries/GetCapacityById/GetCapacityByIdQueryHandler.cs
@@ -1,18 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Capacity.Dtos;
+using Poliedro.Eds.Domain.Capacity.DomainCapacity;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
-using Poliedro.Eds.Domain.Capacity.DomainCapacity;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Capacity.Queries.GetCapacityById;
 public class GetCapacityByIdQueryHandler(
     ICapacityGetByIdService CapacityGetByIdService,
-    IMapper mapper)
+    IMapper mapper,
+    IValidator<GetCapacityByIdQuery> validator)
     : IRequestHandler<GetCapacityByIdQuery, Result<CapacityDto, Error>>
 {
     public async Task<Result<CapacityDto, Error>> Handle(GetCapacityByIdQuery request, CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+        {
+            return Result<CapacityDto, Error>.Failure(
+            Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+        }
+
         var result = await CapacityGetByIdService.GetByIdAsync(request.Id);
         if (!result.IsSuccess)
             return result.Error!;

--- a/Poliedro.Eds.Application/Category/Commands/CreateCategory/CreateCategoryCommandHandler.cs
+++ b/Poliedro.Eds.Application/Category/Commands/CreateCategory/CreateCategoryCommandHandler.cs
@@ -1,22 +1,31 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Category.DomainCategory;
 using Poliedro.Eds.Domain.Category.Entities;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Category.Commands.CreateCategory;
     public class CreateCategoryCommandHandler(
         ICategoryCreateService categoryDomainService,
-        IMapper mapper) : IRequestHandler<CreateCategoryCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateCategoryRequestDto> validator
+        ) : IRequestHandler<CreateCategoryCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateCategoryCommand request, CancellationToken cancellationToken)
         {
-        var categoryEntity = mapper.Map<CategoryEntity>(request.Request);
-        var result = await categoryDomainService.CreateAsync(categoryEntity);
-            if (!result.IsSuccess)
-                return result.Error!;
-            return result.Value!;
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
+            var categoryEntity = mapper.Map<CategoryEntity>(request.Request);
+            var result = await categoryDomainService.CreateAsync(categoryEntity);
+                if (!result.IsSuccess)
+                    return result.Error!;
+                return result.Value!;
         }
     }
 

--- a/Poliedro.Eds.Application/Category/Commands/UpdateCategory/UpdateCategoryCommandHandler.cs
+++ b/Poliedro.Eds.Application/Category/Commands/UpdateCategory/UpdateCategoryCommandHandler.cs
@@ -1,19 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Category.DomainCategory;
 using Poliedro.Eds.Domain.Category.Entities;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Category.Commands.UpdateCategory
 {
     public class UpdateCategoryCommandHandler(
         ICategoryUpdateService categoryDomainCategory,
-        IMapper mapper
-   ) : IRequestHandler<UpdateCategoryCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateCategoryCommand> validator
+        ) : IRequestHandler<UpdateCategoryCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateCategoryCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var categoryEntity = mapper.Map<CategoryEntity>(request);
             var result = await categoryDomainCategory.UpdateAsync(categoryEntity);
 

--- a/Poliedro.Eds.Application/Category/Queries/GetCategoryById/GetCategoryByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Category/Queries/GetCategoryById/GetCategoryByIdQueryHandler.cs
@@ -1,23 +1,34 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
+using Poliedro.Eds.Application.Business.Queries.GetBusinessById;
 using Poliedro.Eds.Application.Category.Dtos;
 using Poliedro.Eds.Domain.Category.DomainCategory;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Category.Queries.GetCategoryById;
     public class GetCategoryByIdQueryHandler(
         ICategoryGetByIdService categoryDomainService,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetCategoryByIdQuery> validator)
         : IRequestHandler<GetCategoryByIdQuery, Result<CategoryDto, Error>>
     {
         public async Task<Result<CategoryDto, Error>> Handle(GetCategoryByIdQuery request, CancellationToken cancellationToken)
         {
-            var result = await categoryDomainService.GetByIdAsync(request.Id);
-            if (!result.IsSuccess)
-                return result.Error!;
+        var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<CategoryDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
 
-            return mapper.Map<CategoryDto>(result.Value);
-        }
+            var result = await categoryDomainService.GetByIdAsync(request.Id);
+                if (!result.IsSuccess)
+                    return result.Error!;
+
+                return mapper.Map<CategoryDto>(result.Value);
+            }
     }
 

--- a/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentCommandHandler.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentCommandHandler.cs
@@ -1,18 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Compartiment.DomainCompartiment;
 using Poliedro.Eds.Domain.Compartiment.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Compartiment.Commands.CreateCompartiment
 {
     public class CreateCompartimentCommandHandler(
         ICompartimentCreateService compartimentDomainService,
-        IMapper mapper) : IRequestHandler<CreateCompartimentCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateCompartimentRequestDto> validator
+        ) : IRequestHandler<CreateCompartimentCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateCompartimentCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var compartimentEntity = mapper.Map<CompartimentEntity>(request.Request);
             var result = await compartimentDomainService.CreateAsync(compartimentEntity);
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Application/Compartiment/Commands/UpdateServer/UpdateCompartimentCommandHandler.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/UpdateServer/UpdateCompartimentCommandHandler.cs
@@ -1,20 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Compartiment.Commands.UpdateCompartiment;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Compartiment.DomainCompartiment;
 using Poliedro.Eds.Domain.Compartiment.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Compartiment.UpdateCompartiment
 {
     public class UpdateCompartimentCommandHandler(
         ICompartimentUpdateService compartimentDomainCompartiment,
-        IMapper mapper
-   ) : IRequestHandler<UpdateCompartimentCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateCompartimentCommand> validator
+        ) : IRequestHandler<UpdateCompartimentCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateCompartimentCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var compartimentEntity = mapper.Map<CompartimentEntity>(request);
             var result = await compartimentDomainCompartiment.UpdateAsync(compartimentEntity);
 

--- a/Poliedro.Eds.Application/Compartiment/Queries/GetDispensersById/GetCompartimentByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Compartiment/Queries/GetDispensersById/GetCompartimentByIdQueryHandler.cs
@@ -1,19 +1,29 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Compartiment.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Compartiment.DomainCompartiment;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Compartiment.Queries.GetCompartimentById
 {
     public class GetCompartimentByIdQueryHandler(
         ICompartimentGetByIdService compartimentDomainService,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetCompartimentByIdQuery> validator)
         : IRequestHandler<GetCompartimentByIdQuery, Result<CompartimentDto, Error>>
     {
         public async Task<Result<CompartimentDto, Error>> Handle(GetCompartimentByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<CompartimentDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
+
             var result = await compartimentDomainService.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/CompartimentCapacity/Commands/CreateCompartimentCapacity/CreateCompartimentCapacityCommandHandler.cs
+++ b/Poliedro.Eds.Application/CompartimentCapacity/Commands/CreateCompartimentCapacity/CreateCompartimentCapacityCommandHandler.cs
@@ -1,22 +1,32 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
+using Poliedro.Eds.Application.Capacity.Commands.CreateCapacity;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.CompartimentCapacity.DomainCompartimentCapacity;
 using Poliedro.Eds.Domain.CompartimentCapacity.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.CompartimentCapacity.Commands.CreateCompartimentCapacity;
     public class CreateCompartimentCapacityCommandHandler(
         ICompartimentCapacityCreateService CompartimentCapacityDomainCompartimentCapacity,
-        IMapper mapper) : IRequestHandler<CreateCompartimentCapacityCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateCompartimentCapacityRequestDto> validator
+        ) : IRequestHandler<CreateCompartimentCapacityCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateCompartimentCapacityCommand request, CancellationToken cancellationToken)
         {
-            var CompartimentCapacityEntity = mapper.Map<CompartimentCapacityEntity>(request.Request);
-            var result = await CompartimentCapacityDomainCompartimentCapacity.CreateAsync(CompartimentCapacityEntity);
-            if (!result.IsSuccess)
-                return result.Error!;
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
-            return result.Value!;
+            var CompartimentCapacityEntity = mapper.Map<CompartimentCapacityEntity>(request.Request);
+                var result = await CompartimentCapacityDomainCompartimentCapacity.CreateAsync(CompartimentCapacityEntity);
+                if (!result.IsSuccess)
+                    return result.Error!;
+
+                return result.Value!;
         }
     }

--- a/Poliedro.Eds.Application/CompartimentCapacity/Commands/UpdateCompartimentCapacity/UpdateCompartimentCapacityCommandHandler.cs
+++ b/Poliedro.Eds.Application/CompartimentCapacity/Commands/UpdateCompartimentCapacity/UpdateCompartimentCapacityCommandHandler.cs
@@ -1,25 +1,34 @@
-﻿using AutoMapper;
+﻿    using AutoMapper;
+using FluentValidation;
 using MediatR;
+using Poliedro.Eds.Application.Capacity.Commands.UpdateCapacity;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.CompartimentCapacity.DomainCompartimentCapacity;
 using Poliedro.Eds.Domain.CompartimentCapacity.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.CompartimentCapacity.Commands.UpdateCompartimentCapacity;
 
     public class UpdateCompartimentCapacityCommandHandler(
         ICompartimentCapacityUpdateService CompartimentCapacityDomainCompartimentCapacity,
-        IMapper mapper
-    ) : IRequestHandler<UpdateCompartimentCapacityCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateCompartimentCapacityCommand> validator
+        ) : IRequestHandler<UpdateCompartimentCapacityCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateCompartimentCapacityCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var CompartimentCapacityEntity = mapper.Map<CompartimentCapacityEntity>(request);
-            var result = await CompartimentCapacityDomainCompartimentCapacity.UpdateAsync(CompartimentCapacityEntity);
+                var result = await CompartimentCapacityDomainCompartimentCapacity.UpdateAsync(CompartimentCapacityEntity);
 
-            if (!result.IsSuccess)
-                return result.Error!;
+                if (!result.IsSuccess)
+                    return result.Error!;
 
-            return result.Value!;
+                return result.Value!;
         }
     }

--- a/Poliedro.Eds.Application/CompartimentCapacity/Queries/GetCompartimentCapacityById/GetCompartimentCapacityByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/CompartimentCapacity/Queries/GetCompartimentCapacityById/GetCompartimentCapacityByIdQueryHandler.cs
@@ -1,23 +1,33 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.CompartimentCapacity.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.CompartimentCapacity.DomainCompartimentCapacity;
+using System.Net;
 
 namespace Poliedro.Eds.Application.CompartimentCapacity.Queries.GetCompartimentCapacityById;
 
     public class GetCompartimentCapacityByIdQueryHandler(
         ICompartimentCapacityGetByIdService CompartimentCapacityDomainCompartimentCapacity,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetCompartimentCapacityByIdQuery> validator)
         : IRequestHandler<GetCompartimentCapacityByIdQuery, Result<CompartimentCapacityDto, Error>>
     {
         public async Task<Result<CompartimentCapacityDto, Error>> Handle(GetCompartimentCapacityByIdQuery request, CancellationToken cancellationToken)
         {
-            var result = await CompartimentCapacityDomainCompartimentCapacity.GetByIdAsync(request.Id);
-            if (!result.IsSuccess)
-                return result.Error!;
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<CompartimentCapacityDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
 
-            return mapper.Map<CompartimentCapacityDto>(result.Value);
-        }
+            var result = await CompartimentCapacityDomainCompartimentCapacity.GetByIdAsync(request.Id);
+                if (!result.IsSuccess)
+                    return result.Error!;
+
+                return mapper.Map<CompartimentCapacityDto>(result.Value);
+            }
     }

--- a/Poliedro.Eds.Application/Court/Commands/CreateCourt/Handler/CreateCourtCommandHandle.cs
+++ b/Poliedro.Eds.Application/Court/Commands/CreateCourt/Handler/CreateCourtCommandHandle.cs
@@ -6,7 +6,6 @@ using Poliedro.Eds.Domain.Court.DomainService;
 using Poliedro.Eds.Domain.Court.Dto;
 using Poliedro.Eds.Domain.Court.Entities;
 using Poliedro.Eds.Domain.Inventory.Entities;
-using System.Text.Json;
 
 namespace Poliedro.Eds.Application.Court.Commands.CreateCourt.Handler
 {
@@ -15,7 +14,8 @@ namespace Poliedro.Eds.Application.Court.Commands.CreateCourt.Handler
         IGetProductAndCompartiment  getProductAndCompartiment,
         IGetExpenditureId getExpenditureId,
         IGetTypeOfCollectionId getTypeOfCollectionId,
-        ICourtUpdateInventoryService courtUpdateInventoryService) : IRequestHandler<CreateCourtCommand, Result<VoidResult, Error>>
+        ICourtUpdateInventoryService courtUpdateInventoryService
+        ) : IRequestHandler<CreateCourtCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateCourtCommand request, CancellationToken cancellationToken)
         {

--- a/Poliedro.Eds.Application/Court/Queris/GetCourtById/GetCourtByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Court/Queris/GetCourtById/GetCourtByIdQueryHandler.cs
@@ -1,19 +1,30 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Court.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Court.DomainService;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Court.Queris.GetCourtById;
 
 public class GetCourtByIdQueryHandler(
         ICourtGetByIdDomainService courtGetByIdDomainService,
-        IMapper mapper) : IRequestHandler<GetCourtByIdQuery, Result<CourtDto, Error>>
+        IMapper mapper,
+        IValidator<GetCourtByIdQuery> validator
+    ) : IRequestHandler<GetCourtByIdQuery, Result<CourtDto, Error>>
 
 {
     public async Task<Result<CourtDto, Error>> Handle(GetCourtByIdQuery request, CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+        {
+            return Result<CourtDto, Error>.Failure(
+            Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+        }
+
         var result = await courtGetByIdDomainService.GetByIdAsync(request.Id);
         if (!result.IsSuccess)
             return result.Error!;

--- a/Poliedro.Eds.Application/CourtDispensersInventory/Commands/CreateCourtDispensersInventory/CreateCourtDispensersInventoryCommandHandler.cs
+++ b/Poliedro.Eds.Application/CourtDispensersInventory/Commands/CreateCourtDispensersInventory/CreateCourtDispensersInventoryCommandHandler.cs
@@ -1,18 +1,26 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.CourtDispensersInventory.DomainCourtDispensersInventory;
 using Poliedro.Eds.Domain.CourtDispensersInventory.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.CourtDispensersInventory.Commands.CreateCourtDispensersInventory
 {
     public class CreateCourtDispensersInventoryCommandHandler(
         ICourtDispensersInventoryCreateCourtDispensersInventory courtdispensersinventoryDomainCourtDispensersInventory,
-        IMapper mapper) : IRequestHandler<CreateCourtDispensersInventoryCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateCourtDispensersInventoryRequestDto> validator
+        ) : IRequestHandler<CreateCourtDispensersInventoryCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateCourtDispensersInventoryCommand request, CancellationToken cancellationToken)
-        {      
+        {
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
             var courtdispensersinventoryEntity = mapper.Map<CourtDispensersInventoryEntity>(request.Request);
             var result = await courtdispensersinventoryDomainCourtDispensersInventory.CreateAsync(courtdispensersinventoryEntity);

--- a/Poliedro.Eds.Application/CourtDispensersInventory/Commands/UpdateCourtDispensersInventory/UpdateCourtDispensersInventoryCommandHandler.cs
+++ b/Poliedro.Eds.Application/CourtDispensersInventory/Commands/UpdateCourtDispensersInventory/UpdateCourtDispensersInventoryCommandHandler.cs
@@ -1,19 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.CourtDispensersInventory.DomainCourtDispensersInventory;
 using Poliedro.Eds.Domain.CourtDispensersInventory.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.CourtDispensersInventory.Commands.UpdateCourtDispensersInventory
 {
     public class UpdateCourtDispensersInventoryCommandHandler(
         ICourtDispensersInventoryUpdateCourtDispensersInventory courtdispensersinventoryDomainCourtDispensersInventory,
-        IMapper mapper
-    ) : IRequestHandler<UpdateCourtDispensersInventoryCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateCourtDispensersInventoryCommand> validator
+        ) : IRequestHandler<UpdateCourtDispensersInventoryCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateCourtDispensersInventoryCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var courtdispensersinventoryEntity = mapper.Map<CourtDispensersInventoryEntity>(request);
             var result = await courtdispensersinventoryDomainCourtDispensersInventory.UpdateAsync(courtdispensersinventoryEntity);
 

--- a/Poliedro.Eds.Application/CourtDispensersInventory/Queries/GetCourtDispensersInventoryById/GetCourtDispensersInventoryByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/CourtDispensersInventory/Queries/GetCourtDispensersInventoryById/GetCourtDispensersInventoryByIdQueryHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.CourtDispensersInventory.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.CourtDispensersInventory.DomainCourtDispensersInventory;
+using System.Net;
 
 namespace Poliedro.Eds.Application.CourtDispensersInventory.Queries.GetCourtDispensersInventoryById
 {
     public class GetCourtDispensersInventoryByIdQueryHandler(
         ICourtDispensersInventoryGetByIdCourtDispensersInventory courtdispensersinventoryDomainCourtDispensersInventory,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetCourtDispensersInventoryByIdQuery> validator)
         : IRequestHandler<GetCourtDispensersInventoryByIdQuery, Result<CourtDispensersInventoryDto, Error>>
     {
         public async Task<Result<CourtDispensersInventoryDto, Error>> Handle(GetCourtDispensersInventoryByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<CourtDispensersInventoryDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await courtdispensersinventoryDomainCourtDispensersInventory.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/DispenserType/Commands/CreateServer/CreateDispenserTypeCommandHandler.cs
+++ b/Poliedro.Eds.Application/DispenserType/Commands/CreateServer/CreateDispenserTypeCommandHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.DispenserType.DomainDispenserType;
 using Poliedro.Eds.Domain.DispenserType.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.DispenserType.Commands.CreateDispenserType
 
 {
     public class CreateDispenserTypeCommandHandler(
         IDispenserTypeCreateDispenserType dispenserTypeDomainService,
-        IMapper mapper) : IRequestHandler<CreateDispenserTypeCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateDispenserTypeRequestDto> validator
+        ) : IRequestHandler<CreateDispenserTypeCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateDispenserTypeCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var dispenserTypeEntity = mapper.Map<DispenserTypeEntity>(request.Request);
             var result = await dispenserTypeDomainService.CreateAsync(dispenserTypeEntity);
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Application/DispenserType/Commands/UpdateServer/UpdateDispenserTypeCommandHandler.cs
+++ b/Poliedro.Eds.Application/DispenserType/Commands/UpdateServer/UpdateDispenserTypeCommandHandler.cs
@@ -1,20 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.DispenserType.Commands.UpdateDispenserType;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.DispenserType.DomainDispenserType;
 using Poliedro.Eds.Domain.DispenserType.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.DispenserType.Commands.UpdateDispneserType
 {
     public class UpdateDispenserTypeCommandHandler(
         IDispenserTypeUpdateDispenserType dispenserTypeDomainDispenserType,
-        IMapper mapper
+        IMapper mapper,
+        IValidator<UpdateDispenserTypeCommand> validator
     ) : IRequestHandler<UpdateDispenserTypeCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateDispenserTypeCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var dispenserTypeEntity = mapper.Map<DispenserTypeEntity>(request);
             var result = await dispenserTypeDomainDispenserType.UpdateAsync(dispenserTypeEntity);
         

--- a/Poliedro.Eds.Application/DispenserType/Queries/GetDispensersById/GetDispenserTypeByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/DispenserType/Queries/GetDispensersById/GetDispenserTypeByIdQueryHandler.cs
@@ -1,19 +1,29 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
+using Poliedro.Eds.Application.Business.Queries.GetBusinessById;
 using Poliedro.Eds.Application.DispenserType.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.DispenserType.DomainDispenserType;
+using System.Net;
 
 namespace Poliedro.Eds.Application.DispenserType.Queries.GetDispenserTypeById
 {
     public class GetDispenserTypeByIdQueryHandler(
         IDispenserTypeGetByIdDispenserType dispenserTypeDomainService,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetDispenserTypeByIdQuery> validator)
         : IRequestHandler<GetDispenserTypeByIdQuery, Result<DispenserTypeDto, Error>>
     {
         public async Task<Result<DispenserTypeDto, Error>> Handle(GetDispenserTypeByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<DispenserTypeDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await dispenserTypeDomainService.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;
@@ -21,4 +31,4 @@ namespace Poliedro.Eds.Application.DispenserType.Queries.GetDispenserTypeById
             return mapper.Map<DispenserTypeDto>(result.Value);
         }
     }
-}
+}   

--- a/Poliedro.Eds.Application/Dispensers/Commands/CreateServer/CreateDispensersCommandHandler.cs
+++ b/Poliedro.Eds.Application/Dispensers/Commands/CreateServer/CreateDispensersCommandHandler.cs
@@ -1,18 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Dispensers.DomainDispensers;
 using Poliedro.Eds.Domain.Dispensers.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Dispensers.Commands.CreateDispensers
 {
     public class CreateDispensersCommandHandler(
         IDispensersCreateDispensers dispensersDomainService,
-        IMapper mapper) : IRequestHandler<CreateDispensersCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateDispensersRequestDto> validator
+        ) : IRequestHandler<CreateDispensersCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateDispensersCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var dispensersEntity = mapper.Map<DispensersEntity>(request.Request);
             var result = await dispensersDomainService.CreateAsync(dispensersEntity);
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Application/Dispensers/Commands/UpdateServer/UpdateDispensersCommandHandler.cs
+++ b/Poliedro.Eds.Application/Dispensers/Commands/UpdateServer/UpdateDispensersCommandHandler.cs
@@ -1,19 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Dispensers.DomainDispensers;
 using Poliedro.Eds.Domain.Dispensers.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Dispensers.Commands.UpdateDispensers
 {
     public class UpdateDispensersCommandHandler(
         IDispensersUpdateDispensers dispensersDomainDispensers,
-        IMapper mapper
-   ) : IRequestHandler<UpdateDispensersCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateDispensersCommand> validator
+        ) : IRequestHandler<UpdateDispensersCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateDispensersCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var dispensersEntity = mapper.Map<DispensersEntity>(request);
             var result = await dispensersDomainDispensers.UpdateAsync(dispensersEntity);
 

--- a/Poliedro.Eds.Application/Dispensers/Queries/GetDispensersById/GetDispensersByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Dispensers/Queries/GetDispensersById/GetDispensersByIdQueryHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Dispensers.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Dispensers.DomainDispensers;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Dispensers.Queries.GetDispensersById
 {
     public class GetDispensersByIdQueryHandler(
         IDispensersGetByIdDispensers dispensersDomainService,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetDispensersByIdQuery> validator)
         : IRequestHandler<GetDispensersByIdQuery, Result<DispensersDto, Error>>
     {
         public async Task<Result<DispensersDto, Error>> Handle(GetDispensersByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<DispensersDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await dispensersDomainService.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/Eds/Commands/CreateEds/CreateEdsCommandHandler.cs
+++ b/Poliedro.Eds.Application/Eds/Commands/CreateEds/CreateEdsCommandHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Eds.DomainEds;
 using Poliedro.Eds.Domain.Eds.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Eds.Commands.CreateEds;
 
 public class CreateEdsCommandHandler(
     IEdsCreateService EdsCreateService,
-    IMapper mapper) : IRequestHandler<CreateEdsCommand, Result<VoidResult, Error>>
+    IMapper mapper,
+    IValidator<CreateEdsRequestDto> validator
+    ) : IRequestHandler<CreateEdsCommand, Result<VoidResult, Error>>
 {
     public async Task<Result<VoidResult, Error>> Handle(CreateEdsCommand request, CancellationToken cancellationToken)
     {
-            var EdsEntity = mapper.Map<EdsEntity>(request.Request);
+        var validationResult = await validator.ValidateAsync(request.Request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
+        var EdsEntity = mapper.Map<EdsEntity>(request.Request);
         var result = await EdsCreateService.CreateAsync(EdsEntity);
         if (!result.IsSuccess)
             return result.Error!;

--- a/Poliedro.Eds.Application/Eds/Commands/UpdateEds/UpdateEdsCommandHandler.cs
+++ b/Poliedro.Eds.Application/Eds/Commands/UpdateEds/UpdateEdsCommandHandler.cs
@@ -1,17 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
-using Poliedro.Eds.Domain.Eds.DomainEds;
-using Poliedro.Eds.Domain.Eds.Entities;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
+using Poliedro.Eds.Domain.Eds.DomainEds;
+using Poliedro.Eds.Domain.Eds.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Eds.Commands.UpdateEds;
 
-public class UpdateEdsCommandHandler(IEdsUpdateService EdsUpdateService, IMapper mapper) : IRequestHandler<UpdateEdsCommand, Result<VoidResult, Error>>
+public class UpdateEdsCommandHandler(
+    IEdsUpdateService EdsUpdateService,
+    IMapper mapper,
+    IValidator<UpdateEdsCommand> validator
+    ) : IRequestHandler<UpdateEdsCommand, Result<VoidResult, Error>>
 {
-    public async Task<Result<VoidResult, Error>> Handle(UpdateEdsCommand request,
-        CancellationToken cancellationToken)
+    public async Task<Result<VoidResult, Error>> Handle(UpdateEdsCommand request,CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
         var EdsEntity = mapper.Map<EdsEntity>(request);
         var result = await EdsUpdateService.UpdateAsync(EdsEntity);
 

--- a/Poliedro.Eds.Application/Eds/Queries/GetEdsById/GetEdsByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Eds/Queries/GetEdsById/GetEdsByIdQueryHandler.cs
@@ -1,19 +1,29 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Eds.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Eds.DomainEds;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Eds.Queries.GetEdsById;
 
 public class GetEdsByIdQueryHandler(
     IEdsGetByIdService EdsGetByIdService,
-    IMapper mapper)
+    IMapper mapper,
+    IValidator<GetEdsByIdQuery> validator)
     : IRequestHandler<GetEdsByIdQuery, Result<EdsDto, Error>>
 {
     public async Task<Result<EdsDto, Error>> Handle(GetEdsByIdQuery request, CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+        {
+            return Result<EdsDto, Error>.Failure(
+            Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+        }
+
         var result = await EdsGetByIdService.GetByIdAsync(request.Id);
         if (!result.IsSuccess)
             return result.Error!;

--- a/Poliedro.Eds.Application/EdsTank/Commands/CreateEdsTank/CreateEdsTankCommandHandler.cs
+++ b/Poliedro.Eds.Application/EdsTank/Commands/CreateEdsTank/CreateEdsTankCommandHandler.cs
@@ -1,22 +1,31 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.EdsTank.DomainEdsTank;
 using Poliedro.Eds.Domain.EdsTank.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.EdsTank.Commands.CreateEdsTank;
     public class CreateEdsTankCommandHandler(
         IEdsTankCreateEdsTank EdsTankDomainEdsTank,
-        IMapper mapper) : IRequestHandler<CreateEdsTankCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateEdsTankRequestDto> validator
+        ) : IRequestHandler<CreateEdsTankCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateEdsTankCommand request, CancellationToken cancellationToken)
         {
-            var EdsTankEntity = mapper.Map<EdsTankEntity>(request.Request);
-            var result = await EdsTankDomainEdsTank.CreateAsync(EdsTankEntity);
-            if (!result.IsSuccess)
-                return result.Error!;
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
-            return result.Value!;
-        }
-    }
+            var EdsTankEntity = mapper.Map<EdsTankEntity>(request.Request);
+                var result = await EdsTankDomainEdsTank.CreateAsync(EdsTankEntity);
+                if (!result.IsSuccess)
+                    return result.Error!;
+
+                return result.Value!;
+            }
+    }   

--- a/Poliedro.Eds.Application/EdsTank/Commands/UpdateEdsTank/UpdateEdsTankCommandHandler.cs
+++ b/Poliedro.Eds.Application/EdsTank/Commands/UpdateEdsTank/UpdateEdsTankCommandHandler.cs
@@ -1,25 +1,34 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
+using Poliedro.Eds.Application.Capacity.Commands.UpdateCapacity;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.EdsTank.DomainEdsTank;
 using Poliedro.Eds.Domain.EdsTank.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.EdsTank.Commands.UpdateEdsTank;
 
     public class UpdateEdsTankCommandHandler(
         IEdsTankUpdateEdsTank EdsTankDomainEdsTank,
-        IMapper mapper
-    ) : IRequestHandler<UpdateEdsTankCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateEdsTankCommand> validator
+        ) : IRequestHandler<UpdateEdsTankCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateEdsTankCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var EdsTankEntity = mapper.Map<EdsTankEntity>(request);
-            var result = await EdsTankDomainEdsTank.UpdateAsync(EdsTankEntity);
+                var result = await EdsTankDomainEdsTank.UpdateAsync(EdsTankEntity);
 
-            if (!result.IsSuccess)
-                return result.Error!;
+                if (!result.IsSuccess)
+                    return result.Error!;
 
-            return result.Value!;
+                return result.Value!;
         }
     }

--- a/Poliedro.Eds.Application/EdsTank/Queries/GetEdsTankById/GetEdsTankByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/EdsTank/Queries/GetEdsTankById/GetEdsTankByIdQueryHandler.cs
@@ -1,22 +1,31 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.EdsTank.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.EdsTank.DomainEdsTank;
+using System.Net;
 
 namespace Poliedro.Eds.Application.EdsTank.Queries.GetEdsTankById;
     public class GetEdsTankByIdQueryHandler(
         IEdsTankGetByIdEdsTank EdsTankDomainEdsTank,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetEdsTankByIdQuery> validator)
         : IRequestHandler<GetEdsTankByIdQuery, Result<EdsTankDto, Error>>
     {
         public async Task<Result<EdsTankDto, Error>> Handle(GetEdsTankByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<EdsTankDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await EdsTankDomainEdsTank.GetByIdAsync(request.Id);
-            if (!result.IsSuccess)
-                return result.Error!;
+                if (!result.IsSuccess)
+                    return result.Error!;
 
-            return mapper.Map<EdsTankDto>(result.Value);
+                return mapper.Map<EdsTankDto>(result.Value);
         }
     }

--- a/Poliedro.Eds.Application/Expenditures/Commands/CreateExpenditures/CreateExpendituresCommandHandler.cs
+++ b/Poliedro.Eds.Application/Expenditures/Commands/CreateExpenditures/CreateExpendituresCommandHandler.cs
@@ -1,23 +1,32 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Expenditures.DomainExpenditures;
 using Poliedro.Eds.Domain.Expenditures.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Expenditures.Commands.CreateExpenditures;
     public class CreateExpendituresCommandHandler(
         IExpendituresCreateExpenditures ExpendituresDomainExpenditures,
-        IMapper mapper) : IRequestHandler<CreateExpendituresCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateExpendituresRequestDto> validator
+        ) : IRequestHandler<CreateExpendituresCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateExpendituresCommand request, CancellationToken cancellationToken)
         {
-            var ExpendituresEntity = mapper.Map<ExpendituresEntity>(request.Request);
-            var result = await ExpendituresDomainExpenditures.CreateAsync(ExpendituresEntity);
-            if (!result.IsSuccess)
-                return result.Error!;
+            var validationResult = await validator.ValidateAsync(request.Request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
-            return result.Value!;
+                var ExpendituresEntity = mapper.Map<ExpendituresEntity>(request.Request);
+                var result = await ExpendituresDomainExpenditures.CreateAsync(ExpendituresEntity);
+                if (!result.IsSuccess)
+                    return result.Error!;
+
+                return result.Value!;
         }
     }
 

--- a/Poliedro.Eds.Application/Expenditures/Commands/UpdateExpenditures/UpdateExpendituresCommandHandler.cs
+++ b/Poliedro.Eds.Application/Expenditures/Commands/UpdateExpenditures/UpdateExpendituresCommandHandler.cs
@@ -1,25 +1,33 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Expenditures.DomainExpenditures;
 using Poliedro.Eds.Domain.Expenditures.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Expenditures.Commands.UpdateExpenditures;
 
     public class UpdateExpendituresCommandHandler(
         IExpendituresUpdateExpenditures ExpendituresDomainExpenditures,
-        IMapper mapper
-    ) : IRequestHandler<UpdateExpendituresCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateExpendituresCommand> validator
+        ) : IRequestHandler<UpdateExpendituresCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateExpendituresCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var ExpendituresEntity = mapper.Map<ExpendituresEntity>(request);
-            var result = await ExpendituresDomainExpenditures.UpdateAsync(ExpendituresEntity);
+                var result = await ExpendituresDomainExpenditures.UpdateAsync(ExpendituresEntity);
 
-            if (!result.IsSuccess)
-                return result.Error!;
+                if (!result.IsSuccess)
+                    return result.Error!;
 
-            return result.Value!;
+                return result.Value!;
         }
     }

--- a/Poliedro.Eds.Application/Expenditures/Queries/GetExpendituresById/GetExpendituresByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Expenditures/Queries/GetExpendituresById/GetExpendituresByIdQueryHandler.cs
@@ -1,23 +1,32 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Expenditures.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Expenditures.DomainExpenditures;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Expenditures.Queries.GetExpendituresById;
 
     public class GetExpendituresByIdQueryHandler(
         IExpendituresGetByIdExpenditures ExpendituresDomainExpenditures,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetExpendituresByIdQuery> validator)
         : IRequestHandler<GetExpendituresByIdQuery, Result<ExpendituresDto, Error>>
     {
         public async Task<Result<ExpendituresDto, Error>> Handle(GetExpendituresByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<ExpendituresDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await ExpendituresDomainExpenditures.GetByIdAsync(request.Id);
-            if (!result.IsSuccess)
-                return result.Error!;
+                if (!result.IsSuccess)
+                    return result.Error!;
 
-            return mapper.Map<ExpendituresDto>(result.Value);
+                return mapper.Map<ExpendituresDto>(result.Value);
         }
     }

--- a/Poliedro.Eds.Application/Hose/Commands/CreateHose/CreateHoseCommandHandler.cs
+++ b/Poliedro.Eds.Application/Hose/Commands/CreateHose/CreateHoseCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Hose.Errors;
 using Poliedro.Eds.Application.Ports.Redis;
@@ -6,6 +7,7 @@ using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Hose.DomainHose;
 using Poliedro.Eds.Domain.Hose.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Hose.Commands.CreateHose
 {
@@ -13,10 +15,16 @@ namespace Poliedro.Eds.Application.Hose.Commands.CreateHose
         IHoseCreateHose hoseDomainHose,
         IHoseQueryService hoseQueryService,
         IRedisService redisService,
-        IMapper mapper) : IRequestHandler<CreateHoseCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateHoseRequestDto> validator
+        ):  IRequestHandler<CreateHoseCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateHoseCommand request, CancellationToken cancellationToken)
-        {      
+        {
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
             var hoseEntity = mapper.Map<HoseEntity>(request.Request);
 

--- a/Poliedro.Eds.Application/Hose/Commands/UpdateHose/UpdateHoseCommandHandler.cs
+++ b/Poliedro.Eds.Application/Hose/Commands/UpdateHose/UpdateHoseCommandHandler.cs
@@ -1,19 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Hose.DomainHose;
 using Poliedro.Eds.Domain.Hose.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Hose.Commands.UpdateHose
 {
     public class UpdateHoseCommandHandler(
         IHoseUpdateHose hoseDomainHose,
-        IMapper mapper
+        IMapper mapper,
+        IValidator<UpdateHoseCommand> validator
     ) : IRequestHandler<UpdateHoseCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateHoseCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var hoseEntity = mapper.Map<HoseEntity>(request);
             var result = await hoseDomainHose.UpdateAsync(hoseEntity);
 

--- a/Poliedro.Eds.Application/Hose/Queries/GetHoseById/GetHoseByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Hose/Queries/GetHoseById/GetHoseByIdQueryHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Hose.DomainHose;
 using Poliedro.Eds.Domain.Hose.Dtos;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Hose.Queries.GetHoseById
 {
     public class GetHoseByIdQueryHandler(
         IHoseGetByIdHose hoseDomainHose,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetHoseByIdQuery> validator)
         : IRequestHandler<GetHoseByIdQuery, Result<HoseDto, Error>>
     {
         public async Task<Result<HoseDto, Error>> Handle(GetHoseByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<HoseDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await hoseDomainHose.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/HoseHistory/Commands/CreateHoseHistory/CreateHoseHistoryCommandHandler.cs
+++ b/Poliedro.Eds.Application/HoseHistory/Commands/CreateHoseHistory/CreateHoseHistoryCommandHandler.cs
@@ -1,18 +1,26 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.HoseHistory.DomainHoseHistory;
 using Poliedro.Eds.Domain.HoseHistory.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.HoseHistory.Commands.CreateHoseHistory
 {
     public class CreateHoseHistoryCommandHandler(
         IHoseHistoryCreateHoseHistory hosehistoryDomainHoseHistory,
-        IMapper mapper) : IRequestHandler<CreateHoseHistoryCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateHoseHistoryRequestDto> validator
+        ) : IRequestHandler<CreateHoseHistoryCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateHoseHistoryCommand request, CancellationToken cancellationToken)
-        {      
+        {
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
             var hosehistoryEntity = mapper.Map<HoseHistoryEntity>(request.Request);
             var result = await hosehistoryDomainHoseHistory.CreateAsync(hosehistoryEntity);

--- a/Poliedro.Eds.Application/HoseHistory/Commands/UpdateHoseHistory/UpdateHoseHistoryCommandHandler.cs
+++ b/Poliedro.Eds.Application/HoseHistory/Commands/UpdateHoseHistory/UpdateHoseHistoryCommandHandler.cs
@@ -1,19 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.HoseHistory.DomainHoseHistory;
 using Poliedro.Eds.Domain.HoseHistory.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.HoseHistory.Commands.UpdateHoseHistory
 {
     public class UpdateHoseHistoryCommandHandler(
         IHoseHistoryUpdateHoseHistory hosehistoryDomainHoseHistory,
-        IMapper mapper
-    ) : IRequestHandler<UpdateHoseHistoryCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateHoseHistoryCommand> validator
+        ) : IRequestHandler<UpdateHoseHistoryCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateHoseHistoryCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var hosehistoryEntity = mapper.Map<HoseHistoryEntity>(request);
             var result = await hosehistoryDomainHoseHistory.UpdateAsync(hosehistoryEntity);
 

--- a/Poliedro.Eds.Application/HoseHistory/Queries/GetHoseHistoryById/GetHoseHistoryByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/HoseHistory/Queries/GetHoseHistoryById/GetHoseHistoryByIdQueryHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.HoseHistory.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.HoseHistory.DomainHoseHistory;
+using System.Net;
 
 namespace Poliedro.Eds.Application.HoseHistory.Queries.GetHoseHistoryById
 {
     public class GetHoseHistoryByIdQueryHandler(
         IHoseHistoryGetByIdHoseHistory hosehistoryDomainHoseHistory,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetHoseHistoryByIdQuery> validator)
         : IRequestHandler<GetHoseHistoryByIdQuery, Result<HoseHistoryDto, Error>>
     {
         public async Task<Result<HoseHistoryDto, Error>> Handle(GetHoseHistoryByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<HoseHistoryDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await hosehistoryDomainHoseHistory.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/Island/Commands/CreateIsland/CreateIslandCommandHandler.cs
+++ b/Poliedro.Eds.Application/Island/Commands/CreateIsland/CreateIslandCommandHandler.cs
@@ -1,18 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Island.DomainIsland;
 using Poliedro.Eds.Domain.Island.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Island.Commands.CreateIsland
 {
     public class CreateIslandCommandHandler(
         IIslandCreateIsland islandDomainIsland,
-        IMapper mapper) : IRequestHandler<CreateIslandCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateIslandRequestDto> validator
+        ) : IRequestHandler<CreateIslandCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateIslandCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var islandEntity = mapper.Map<IslandEntity>(request.Request);
             var result = await islandDomainIsland.CreateAsync(islandEntity);
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Application/Island/Commands/UpdateIsland/UpdateIslandCommandHandler.cs
+++ b/Poliedro.Eds.Application/Island/Commands/UpdateIsland/UpdateIslandCommandHandler.cs
@@ -1,18 +1,26 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Island.DomainIsland;
 using Poliedro.Eds.Domain.Island.Entities;
+using System.Net;
 namespace Poliedro.Eds.Application.Island.Commands.UpdateIsland
 {
     public class UpdateIslandCommandHandler(
         IIslandUpdateIsland islandDomainIsland,
-        IMapper mapper
-    ) : IRequestHandler<UpdateIslandCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateIslandCommand> validator
+        ) : IRequestHandler<UpdateIslandCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateIslandCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var islandEntity = mapper.Map<IslandEntity>(request);
             var result = await islandDomainIsland.UpdateAsync(islandEntity);
 

--- a/Poliedro.Eds.Application/Island/Queries/GetIslandById/GetIslandByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Island/Queries/GetIslandById/GetIslandByIdQueryHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Island.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Island.DomainIsland;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Island.Queries.GetIslandById
 {
     public class GetIslandByIdQueryHandler(
         IIslandGetByIdIsland islandDomainIsland,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetIslandByIdQuery> validator)
         : IRequestHandler<GetIslandByIdQuery, Result<IslandDto, Error>>
     {
         public async Task<Result<IslandDto, Error>> Handle(GetIslandByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<IslandDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await islandDomainIsland.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/Islander/Commands/CreateIslander/CreateIslanderCommandHandler.cs
+++ b/Poliedro.Eds.Application/Islander/Commands/CreateIslander/CreateIslanderCommandHandler.cs
@@ -1,22 +1,29 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Islander.DomainIslander;
 using Poliedro.Eds.Domain.Islander.Entities;
+using RabbitMQ.Client;
+using System.Net;
 using System.Text;
 using System.Text.Json;
-using RabbitMQ.Client;
 
 namespace Poliedro.Eds.Application.Islander.Commands.CreateIslander
 {
     public class CreateIslanderCommandHandler(
         IIslanderCreateIslander islanderDomainIslander,
         IMapper mapper,
+        IValidator<CreateIslanderRequestDto> validator,
         IConnection rabbitConnection) : IRequestHandler<CreateIslanderCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateIslanderCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
             var islanderEntity = mapper.Map<IslanderEntity>(request.Request);
 

--- a/Poliedro.Eds.Application/Islander/Commands/UpdateIslander/UpdateIslanderCommandHandler.cs
+++ b/Poliedro.Eds.Application/Islander/Commands/UpdateIslander/UpdateIslanderCommandHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
+using Poliedro.Eds.Application.Capacity.Commands.UpdateCapacity;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Islander.DomainIslander;
 using Poliedro.Eds.Domain.Islander.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Islander.Commands.UpdateIslander
 {
     public class UpdateIslanderCommandHandler(
         IIslanderUpdateIslander islanderDomainIslander,
-        IMapper mapper
+        IMapper mapper,
+        IValidator<UpdateIslanderCommand> validator
     ) : IRequestHandler<UpdateIslanderCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateIslanderCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var islanderEntity = mapper.Map<IslanderEntity>(request);
             var result = await islanderDomainIslander.UpdateAsync(islanderEntity);
 

--- a/Poliedro.Eds.Application/Islander/Queries/GetIslanderById/GetIslanderByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Islander/Queries/GetIslanderById/GetIslanderByIdQueryHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Islander.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Islander.DomainIslander;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Islander.Queries.GetIslanderById
 {
     public class GetIslanderByIdQueryHandler(
         IIslanderGetByIdIslander islanderDomainIslander,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetIslanderByIdQuery> validator)
         : IRequestHandler<GetIslanderByIdQuery, Result<IslanderDto, Error>>
     {
         public async Task<Result<IslanderDto, Error>> Handle(GetIslanderByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<IslanderDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await islanderDomainIslander.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/Product/Commands/CreateProduct/CreateProductCommandHandler.cs
+++ b/Poliedro.Eds.Application/Product/Commands/CreateProduct/CreateProductCommandHandler.cs
@@ -1,27 +1,31 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Product.DomainProduct;
 using Poliedro.Eds.Domain.Product.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Product.Commands.CreateProduct;
     public class CreateProductCommandHandler(
         IProductCreateProduct ProductDomainProduct,
-        IMapper mapper) : IRequestHandler<CreateProductCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateProductRequestDto> validator
+        ) : IRequestHandler<CreateProductCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateProductCommand request, CancellationToken cancellationToken)
         {
-            var ProductEntity = mapper.Map<ProductEntity>(request.Request);
-            var result = await ProductDomainProduct.CreateAsync(ProductEntity);
-            if (!result.IsSuccess)
-                return result.Error!;
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
-            return result.Value!;
+            var ProductEntity = mapper.Map<ProductEntity>(request.Request);
+                var result = await ProductDomainProduct.CreateAsync(ProductEntity);
+                if (!result.IsSuccess)
+                    return result.Error!;
+
+                return result.Value!;
         }
     }
-
-
-
-
-

--- a/Poliedro.Eds.Application/Product/Commands/UpdateProduct/UpdateProductCommandHandler.cs
+++ b/Poliedro.Eds.Application/Product/Commands/UpdateProduct/UpdateProductCommandHandler.cs
@@ -1,25 +1,33 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Product.DomainProduct;
 using Poliedro.Eds.Domain.Product.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Product.Commands.UpdateProduct;
 
     public class UpdateProductCommandHandler(
         IProductUpdateProduct ProductDomainProduct,
-        IMapper mapper
+        IMapper mapper,
+        IValidator<UpdateProductCommand> validator
     ) : IRequestHandler<UpdateProductCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateProductCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var ProductEntity = mapper.Map<ProductEntity>(request);
-            var result = await ProductDomainProduct.UpdateAsync(ProductEntity);
+                    var result = await ProductDomainProduct.UpdateAsync(ProductEntity);
 
-            if (!result.IsSuccess)
-                return result.Error!;
+                    if (!result.IsSuccess)
+                        return result.Error!;
 
-            return result.Value!;
+                    return result.Value!;
         }
     }

--- a/Poliedro.Eds.Application/Product/Queries/GetProductById/GetProductByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Product/Queries/GetProductById/GetProductByIdQueryHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Product.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Product.DomainProduct;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Product.Queries.GetProductById
 {
     public class GetProductByIdQueryHandler(
         IProductGetByIdProduct ProductDomainProduct,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetProductByIdQuery> validator)
         : IRequestHandler<GetProductByIdQuery, Result<ProductDto, Error>>
     {
         public async Task<Result<ProductDto, Error>> Handle(GetProductByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<ProductDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await ProductDomainProduct.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/ProductCompartiment/Commands/CreateProductCompartiment/CreateProductCompartimentCommandHandler.cs
+++ b/Poliedro.Eds.Application/ProductCompartiment/Commands/CreateProductCompartiment/CreateProductCompartimentCommandHandler.cs
@@ -1,22 +1,31 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.ProductCompartiment.DomainProductCompartiment;
 using Poliedro.Eds.Domain.ProductCompartiment.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ProductCompartiment.Commands.CreateProductCompartiment;
     public class CreateProductCompartimentCommandHandler(
         IProductCompartimentCreateProductCompartiment ProductCompartimentDomainProductCompartiment,
-        IMapper mapper) : IRequestHandler<CreateProductCompartimentCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateProductCompartimentRequestDto> validator
+        ) : IRequestHandler<CreateProductCompartimentCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateProductCompartimentCommand request, CancellationToken cancellationToken)
         {
-            var ProductCompartimentEntity = mapper.Map<ProductCompartimentEntity>(request.Request);
-            var result = await ProductCompartimentDomainProductCompartiment.CreateAsync(ProductCompartimentEntity);
-            if (!result.IsSuccess)
-                return result.Error!;
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
-            return result.Value!;
+            var ProductCompartimentEntity = mapper.Map<ProductCompartimentEntity>(request.Request);
+                var result = await ProductCompartimentDomainProductCompartiment.CreateAsync(ProductCompartimentEntity);
+                if (!result.IsSuccess)
+                    return result.Error!;
+
+                return result.Value!;
         }
     }

--- a/Poliedro.Eds.Application/ProductCompartiment/Commands/UpdateProductCompartiment/UpdateProductCompartimentCommandHandler.cs
+++ b/Poliedro.Eds.Application/ProductCompartiment/Commands/UpdateProductCompartiment/UpdateProductCompartimentCommandHandler.cs
@@ -1,25 +1,35 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
+using Poliedro.Eds.Application.Capacity.Commands.UpdateCapacity;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.ProductCompartiment.DomainProductCompartiment;
 using Poliedro.Eds.Domain.ProductCompartiment.Entities;
+using System.ComponentModel.DataAnnotations;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ProductCompartiment.Commands.UpdateProductCompartiment;
 
     public class UpdateProductCompartimentCommandHandler(
         IProductCompartimentUpdateProductCompartiment ProductCompartimentDomainProductCompartiment,
-        IMapper mapper
-    ) : IRequestHandler<UpdateProductCompartimentCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateProductCompartimentCommand> validator
+        ) : IRequestHandler<UpdateProductCompartimentCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateProductCompartimentCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var ProductCompartimentEntity = mapper.Map<ProductCompartimentEntity>(request);
-            var result = await ProductCompartimentDomainProductCompartiment.UpdateAsync(ProductCompartimentEntity);
+                var result = await ProductCompartimentDomainProductCompartiment.UpdateAsync(ProductCompartimentEntity);
 
-            if (!result.IsSuccess)
-                return result.Error!;
+                if (!result.IsSuccess)
+                    return result.Error!;
 
-            return result.Value!;
+                return result.Value!;
         }
     }

--- a/Poliedro.Eds.Application/ProductCompartiment/Queries/GetProductCompartimentById/GetProductCompartimentByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/ProductCompartiment/Queries/GetProductCompartimentById/GetProductCompartimentByIdQueryHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.ProductCompartiment.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.ProductCompartiment.DomainProductCompartiment;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ProductCompartiment.Queries.GetProductCompartimentById
 {
     public class GetProductCompartimentByIdQueryHandler(
         IProductCompartimentGetByIdProductCompartiment ProductCompartimentDomainProductCompartiment,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetProductCompartimentByIdQuery> validator)
         : IRequestHandler<GetProductCompartimentByIdQuery, Result<ProductCompartimentDto, Error>>
     {
         public async Task<Result<ProductCompartimentDto, Error>> Handle(GetProductCompartimentByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<ProductCompartimentDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await ProductCompartimentDomainProductCompartiment.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/ProductType/Commands/CreateProductType/CreateProductTypeCommandHandler.cs
+++ b/Poliedro.Eds.Application/ProductType/Commands/CreateProductType/CreateProductTypeCommandHandler.cs
@@ -1,18 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.ProductType.DomainProductType;
 using Poliedro.Eds.Domain.ProductType.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ProductType.Commands.CreateProductType
 {
     public class CreateProductTypeCommandHandler(
         IProductTypeCreateProductType productTypeDomainProductType,
-        IMapper mapper) : IRequestHandler<CreateProductTypeCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateProductTypeRequestDto> validator
+        ) : IRequestHandler<CreateProductTypeCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateProductTypeCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var ProductTypeEntity = mapper.Map<ProductTypeEntity>(request.Request);
             var result = await productTypeDomainProductType.CreateAsync(ProductTypeEntity);
             if (!result.IsSuccess)

--- a/Poliedro.Eds.Application/ProductType/Commands/UpdateProductType/UpdateProductTypeCommandHandler.cs
+++ b/Poliedro.Eds.Application/ProductType/Commands/UpdateProductType/UpdateProductTypeCommandHandler.cs
@@ -1,19 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.ProductType.DomainProductType;
 using Poliedro.Eds.Domain.ProductType.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ProductType.Commands.UpdateProductType
 {
     public class UpdateProductTypeCommandHandler(
         IProductTypeUpdateProductType ProductTypeDomainProductType,
-        IMapper mapper
-    ) : IRequestHandler<UpdateProductTypeCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateProductTypeCommand> validator
+        ) : IRequestHandler<UpdateProductTypeCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateProductTypeCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var ProductTypeEntity = mapper.Map<ProductTypeEntity>(request);
             var result = await ProductTypeDomainProductType.UpdateAsync(ProductTypeEntity);
 

--- a/Poliedro.Eds.Application/ProductType/Queries/GetProductTypeById/GetProductTypeByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/ProductType/Queries/GetProductTypeById/GetProductTypeByIdQueryHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.ProductType.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.ProductType.DomainProductType;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ProductType.Queries.GetProductTypeById
 {
     public class GetProductTypeByIdQueryHandler(
         IProductTypeGetByIdProductType ProductTypeDomainProductType,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetProductTypeByIdQuery> validator)
         : IRequestHandler<GetProductTypeByIdQuery, Result<ProductTypeDto, Error>>
     {
         public async Task<Result<ProductTypeDto, Error>> Handle(GetProductTypeByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<ProductTypeDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await ProductTypeDomainProductType.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/Provider/Commands/CreateProvider/CreateProviderCommandHandler.cs
+++ b/Poliedro.Eds.Application/Provider/Commands/CreateProvider/CreateProviderCommandHandler.cs
@@ -1,18 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Provider.DomainProvider;
 using Poliedro.Eds.Domain.Provider.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Provider.Commands.CreateProvider;
 
 public class CreateProviderCommandHandler(
     IProviderCreateService ProviderCreateService,
-    IMapper mapper) : IRequestHandler<CreateProviderCommand, Result<VoidResult, Error>>
+    IMapper mapper,
+    IValidator<CreateProviderRequestDto> validator
+    ) : IRequestHandler<CreateProviderCommand, Result<VoidResult, Error>>
 {
     public async Task<Result<VoidResult, Error>> Handle(CreateProviderCommand request, CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request.Request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
         var ProviderEntity = mapper.Map<ProviderEntity>(request.Request);
         var result = await ProviderCreateService.CreateAsync(ProviderEntity);
         if (!result.IsSuccess)

--- a/Poliedro.Eds.Application/Provider/Commands/UpdateProvider/UpdateProviderCommandHandler.cs
+++ b/Poliedro.Eds.Application/Provider/Commands/UpdateProvider/UpdateProviderCommandHandler.cs
@@ -1,17 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
-using Poliedro.Eds.Domain.Provider.DomainProvider;
-using Poliedro.Eds.Domain.Provider.Entities;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
+using Poliedro.Eds.Domain.Provider.DomainProvider;
+using Poliedro.Eds.Domain.Provider.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Provider.Commands.UpdateProvider;
 
-public class UpdateProviderCommandHandler(IProviderUpdateService ProviderUpdateService, IMapper mapper) : IRequestHandler<UpdateProviderCommand, Result<VoidResult, Error>>
+public class UpdateProviderCommandHandler(
+    IProviderUpdateService ProviderUpdateService,
+    IMapper mapper,
+    IValidator<UpdateProviderCommand> validator
+    ) : IRequestHandler<UpdateProviderCommand, Result<VoidResult, Error>>
 {
-    public async Task<Result<VoidResult, Error>> Handle(UpdateProviderCommand request,
-        CancellationToken cancellationToken)
+    public async Task<Result<VoidResult, Error>> Handle(UpdateProviderCommand request,CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
         var ProviderEntity = mapper.Map<ProviderEntity>(request);
         var result = await ProviderUpdateService.UpdateAsync(ProviderEntity);
 

--- a/Poliedro.Eds.Application/Provider/Queries/GetProviderById/GetProviderByIdHandler.cs
+++ b/Poliedro.Eds.Application/Provider/Queries/GetProviderById/GetProviderByIdHandler.cs
@@ -1,18 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Provider.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Provider.DomainProvider;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Provider.Queries.GetProviderById;
 public class GetProviderByIdQueryHandler(
     IProviderGetByIdService ProviderGetByIdService,
-    IMapper mapper)
+    IMapper mapper,
+    IValidator<GetProviderByIdQuery> validator)
     : IRequestHandler<GetProviderByIdQuery, Result<ProviderDto, Error>>
 {
     public async Task<Result<ProviderDto, Error>> Handle(GetProviderByIdQuery request, CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+        {
+            return Result<ProviderDto, Error>.Failure(
+            Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+        }
         var result = await ProviderGetByIdService.GetByIdAsync(request.Id);
         if (!result.IsSuccess)
             return result.Error!;

--- a/Poliedro.Eds.Application/Shopping/Commands/CreateShopping/CreateShoppingCommandHandler.cs
+++ b/Poliedro.Eds.Application/Shopping/Commands/CreateShopping/CreateShoppingCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Product.Services;
 using Poliedro.Eds.Domain.Common.Results;
@@ -6,16 +7,23 @@ using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Inventory.Entities;
 using Poliedro.Eds.Domain.Shopping.DomainShopping;
 using Poliedro.Eds.Domain.Shopping.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Shopping.Commands.CreateShopping;
     public class CreateShoppingCommandHandler(
         IShoppingCreateShopping shoppingDomainService,
         IMapper mapper,
+        IValidator<CreateShoppingRequestDto> validator,
         IProductPriceUpdateService productPriceUpdateService
         ) : IRequestHandler<CreateShoppingCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateShoppingCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
 
         var shoppingEntity = mapper.Map<ShoppingEntity>(request.Request);
 

--- a/Poliedro.Eds.Application/Shopping/Commands/UpdateShopping/UpdateShoppingCommandHandler.cs
+++ b/Poliedro.Eds.Application/Shopping/Commands/UpdateShopping/UpdateShoppingCommandHandler.cs
@@ -1,19 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Shopping.DomainShopping;
 using Poliedro.Eds.Domain.Shopping.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Shopping.Commands.UpdateShopping
 {
     public class UpdateShoppingCommandHandler(
         IShoppingUpdateShopping shoppingDomainShopping,
-        IMapper mapper
-   ) : IRequestHandler<UpdateShoppingCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateShoppingCommand> validator
+         ) : IRequestHandler<UpdateShoppingCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateShoppingCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var shoppingEntity = mapper.Map<ShoppingEntity>(request);
             var result = await shoppingDomainShopping.UpdateAsync(shoppingEntity);
 

--- a/Poliedro.Eds.Application/Shopping/Queries/GetShoppingById/GetShoppingByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Shopping/Queries/GetShoppingById/GetShoppingByIdQueryHandler.cs
@@ -1,23 +1,32 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Shopping.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Shopping.DomainShopping;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Shopping.Queries.GetShoppingById;
     public class GetShoppingByIdQueryHandler(
         IShoppingGetByIdShopping shoppingDomainService,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetShoppingByIdQuery> validator)
         : IRequestHandler<GetShoppingByIdQuery, Result<ShoppingDto, Error>>
     {
         public async Task<Result<ShoppingDto, Error>> Handle(GetShoppingByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<ShoppingDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await shoppingDomainService.GetByIdAsync(request.Id);
-            if (!result.IsSuccess)
-                return result.Error!;
+                if (!result.IsSuccess)
+                    return result.Error!;
 
-            return mapper.Map<ShoppingDto>(result.Value);
+                return mapper.Map<ShoppingDto>(result.Value);
         }
     }
 

--- a/Poliedro.Eds.Application/ShoppingProduct/Commands/CreateShoppingProduct/CreateShoppingProductCommandHandler.cs
+++ b/Poliedro.Eds.Application/ShoppingProduct/Commands/CreateShoppingProduct/CreateShoppingProductCommandHandler.cs
@@ -1,24 +1,32 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.ShoppingProduct.DomainShoppingProduct;
 using Poliedro.Eds.Domain.ShoppingProduct.Entities;
-using Poliedro.Eds.Domain.ShoppingProductInventory.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ShoppingProduct.Commands.CreateShoppingProduct;
 public class CreateShoppingProductCommandHandler(
         IShoppingProductCreateShoppingProduct shoppingProductDomainService,
-        IMapper mapper) : IRequestHandler<CreateShoppingProductCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateShoppingProductRequestDto> validator
+        ) : IRequestHandler<CreateShoppingProductCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateShoppingProductCommand request, CancellationToken cancellationToken)
         {
-        var shoppingProductEntity = mapper.Map<ShoppingProductEntity>(request.Request);
-        var result = await shoppingProductDomainService.CreateAsync(shoppingProductEntity);
-            if (!result.IsSuccess)
-                return result.Error!;
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
-            return result.Value!;
+            var shoppingProductEntity = mapper.Map<ShoppingProductEntity>(request.Request);
+            var result = await shoppingProductDomainService.CreateAsync(shoppingProductEntity);
+                if (!result.IsSuccess)
+                    return result.Error!;
+
+                return result.Value!;
         }
     }
 

--- a/Poliedro.Eds.Application/ShoppingProduct/Commands/UpdateShopping/UpdateShoppingProductCommandHandler.cs
+++ b/Poliedro.Eds.Application/ShoppingProduct/Commands/UpdateShopping/UpdateShoppingProductCommandHandler.cs
@@ -1,24 +1,32 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.ShoppingProduct.DomainShoppingProduct;
 using Poliedro.Eds.Domain.ShoppingProduct.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ShoppingProduct.Commands.UpdateShoppingProduct;
     public class UpdateShoppingProductCommandHandler(
         IShoppingProductUpdateShoppingProduct shoppingProductDomainShoppingProduct,
-        IMapper mapper
-   ) : IRequestHandler<UpdateShoppingProductCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateShoppingProductCommand> validator
+        ) : IRequestHandler<UpdateShoppingProductCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateShoppingProductCommand request, CancellationToken cancellationToken)
         {
-            var shoppingProductEntity = mapper.Map<ShoppingProductEntity>(request);
-            var result = await shoppingProductDomainShoppingProduct.UpdateAsync(shoppingProductEntity);
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
-            if (!result.IsSuccess)
-                return result.Error!;
-            return result.Value!;
+            var shoppingProductEntity = mapper.Map<ShoppingProductEntity>(request);
+                var result = await shoppingProductDomainShoppingProduct.UpdateAsync(shoppingProductEntity);
+
+                if (!result.IsSuccess)
+                    return result.Error!;
+                return result.Value!;
         }
     }
 

--- a/Poliedro.Eds.Application/ShoppingProduct/Queries/GetShoppingProductById/GetShoppingProductByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/ShoppingProduct/Queries/GetShoppingProductById/GetShoppingProductByIdQueryHandler.cs
@@ -1,23 +1,32 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.ShoppingProduct.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.ShoppingProduct.DomainShoppingProduct;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ShoppingProduct.Queries.GetShoppingProductById;
     public class GetShoppingProductByIdQueryHandler(
         IShoppingProductGetByIdShoppingProduct shoppingProductDomainService,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetShoppingProductByIdQuery> validator)
         : IRequestHandler<GetShoppingProductByIdQuery, Result<ShoppingProductDto, Error>>
     {
         public async Task<Result<ShoppingProductDto, Error>> Handle(GetShoppingProductByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<ShoppingProductDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await shoppingProductDomainService.GetByIdAsync(request.Id);
-            if (!result.IsSuccess)
-                return result.Error!;
+                if (!result.IsSuccess)
+                    return result.Error!;
 
-            return mapper.Map<ShoppingProductDto>(result.Value);
+                return mapper.Map<ShoppingProductDto>(result.Value);
         }
     }
 

--- a/Poliedro.Eds.Application/ShoppingProductInventory/Commands/CreateShoppingProductInventory/CreateShoppingProductInventoryCommandHandler.cs
+++ b/Poliedro.Eds.Application/ShoppingProductInventory/Commands/CreateShoppingProductInventory/CreateShoppingProductInventoryCommandHandler.cs
@@ -1,26 +1,26 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
-using Poliedro.Eds.Application.ShoppingProduct.Commands.CreateShoppingProduct;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
-using Poliedro.Eds.Domain.ShoppingProduct.DomainShoppingProduct;
-using Poliedro.Eds.Domain.ShoppingProduct.Entities;
 using Poliedro.Eds.Domain.ShoppingProductInventory.DomainShoppingProductInventory;
 using Poliedro.Eds.Domain.ShoppingProductInventory.Entities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ShoppingProductInventory.Commands.CreateShoppingProductInventory
 {
-    public class CreateShoppingProductInventoryCommandHandler(IShoppingCreateShoppingProductInventory shoppingProductDomainService, IMapper mapper) : IRequestHandler<CreateShoppingProductInventoryCommand, Result<VoidResult, Error>>
+    public class CreateShoppingProductInventoryCommandHandler(
+        IShoppingCreateShoppingProductInventory shoppingProductDomainService,
+        IMapper mapper,
+        IValidator<CreateShoppingProductInventoryRequestDto> validator
+        ) : IRequestHandler<CreateShoppingProductInventoryCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateShoppingProductInventoryCommand request, CancellationToken cancellationToken)
         {
-            //throw new NotImplementedException();
-
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
             var shoppingProductEntity = mapper.Map<ShoppingProductInventoryEntity>(request.Request);
             var result = await shoppingProductDomainService.CreateAsync(shoppingProductEntity);

--- a/Poliedro.Eds.Application/ShoppingProductInventory/Queries/GetShoppingProductInventoryById/GetShoppingProductInventoryByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/ShoppingProductInventory/Queries/GetShoppingProductInventoryById/GetShoppingProductInventoryByIdQueryHandler.cs
@@ -1,25 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
-using Poliedro.Eds.Application.ShoppingProduct.Dtos;
-using Poliedro.Eds.Application.ShoppingProduct.Queries.GetShoppingProductById;
 using Poliedro.Eds.Application.ShoppingProductInventory.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
-using Poliedro.Eds.Domain.ShoppingProduct.DomainShoppingProduct;
 using Poliedro.Eds.Domain.ShoppingProductInventory.DomainShoppingProductInventory;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Net;
 
 namespace Poliedro.Eds.Application.ShoppingProductInventory.Queries.GetShoppingProductInventoryById
 {
-    public class GetShoppingProductInventoryByIdQueryHandler(IShoppingProductInventoryGetById shoppingProductInventoryDomainService, IMapper mapper) : IRequestHandler<GetShoppingProductInventoryByIdQuery, Result<ShoppingProductInventoryDto, Error>>
+    public class GetShoppingProductInventoryByIdQueryHandler(
+        IShoppingProductInventoryGetById shoppingProductInventoryDomainService,
+        IMapper mapper,
+        IValidator<GetShoppingProductInventoryByIdQuery> validator
+        ) : IRequestHandler<GetShoppingProductInventoryByIdQuery, Result<ShoppingProductInventoryDto, Error>>
     {
         public async Task<Result<ShoppingProductInventoryDto, Error>> Handle(GetShoppingProductInventoryByIdQuery request, CancellationToken cancellationToken)
         {
-
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<ShoppingProductInventoryDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await shoppingProductInventoryDomainService.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/Tank/Commands/CreateTank/CreateTankCommandHandler.cs
+++ b/Poliedro.Eds.Application/Tank/Commands/CreateTank/CreateTankCommandHandler.cs
@@ -1,18 +1,26 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Tank.DomainTank;
 using Poliedro.Eds.Domain.Tank.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Tank.Commands.CreateTank;
 
 public class CreateTankCommandHandler(
     ITankCreateTank tankDomainTank,
-    IMapper mapper) : IRequestHandler<CreateTankCommand, Result<VoidResult, Error>>
+    IMapper mapper,
+    IValidator<CreateTankRequestDto> validator
+    ) : IRequestHandler<CreateTankCommand, Result<VoidResult, Error>>
 {
     public async Task<Result<VoidResult, Error>> Handle(CreateTankCommand request, CancellationToken cancellationToken)
-    {      
+    {
+        var validationResult = await validator.ValidateAsync(request.Request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
         var tankEntity = mapper.Map<TankEntity>(request.Request);
         var result = await tankDomainTank.CreateAsync(tankEntity);

--- a/Poliedro.Eds.Application/Tank/Commands/UpdateTank/UpdateTankCommandHandler.cs
+++ b/Poliedro.Eds.Application/Tank/Commands/UpdateTank/UpdateTankCommandHandler.cs
@@ -1,19 +1,27 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Tank.DomainTank;
 using Poliedro.Eds.Domain.Tank.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Tank.Commands.UpdateTank;
 
 public class UpdateTankCommandHandler(
     ITankUpdateTank tankDomainTank,
-    IMapper mapper
+    IMapper mapper,
+    IValidator<UpdateTankCommand> validator
 ) : IRequestHandler<UpdateTankCommand, Result<VoidResult, Error>>
 {
     public async Task<Result<VoidResult, Error>> Handle(UpdateTankCommand request, CancellationToken cancellationToken)
     {
+        var validationResult = await validator.ValidateAsync(request);
+        if (!validationResult.IsValid)
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
         var tankEntity = mapper.Map<TankEntity>(request);
         var result = await tankDomainTank.UpdateAsync(tankEntity);
 

--- a/Poliedro.Eds.Application/Tank/Queries/GetTankById/GetTankByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/Tank/Queries/GetTankById/GetTankByIdQueryHandler.cs
@@ -1,19 +1,28 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.Tank.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Tank.DomainTank;
+using System.Net;
 
 namespace Poliedro.Eds.Application.Tank.Queries.GetTankById
 {
     public class GetTankByIdQueryHandler(
         ITankGetByIdTank tankDomainTank,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetTankByIdQuery> validator)
         : IRequestHandler<GetTankByIdQuery, Result<TankDto, Error>>
     {
         public async Task<Result<TankDto, Error>> Handle(GetTankByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<TankDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await tankDomainTank.GetByIdAsync(request.Id);
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/TypeOfCollection/Commands/CreateTypeOfCollection/CreateTypeOfCollectionCommandHandler.cs
+++ b/Poliedro.Eds.Application/TypeOfCollection/Commands/CreateTypeOfCollection/CreateTypeOfCollectionCommandHandler.cs
@@ -1,22 +1,31 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.TypeOfCollection.DomainTypeOfCollection;
 using Poliedro.Eds.Domain.TypeOfCollection.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.TypeOfCollection.Commands.CreateTypeOfCollection;
     public class CreateTypeOfCollectionCommandHandler(
         ITypeOfCollectionCreateTypeOfCollection TypeOfCollectionDomainTypeOfCollection,
-        IMapper mapper) : IRequestHandler<CreateTypeOfCollectionCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<CreateTypeOfCollectionRequestDto> validator
+        ) : IRequestHandler<CreateTypeOfCollectionCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateTypeOfCollectionCommand request, CancellationToken cancellationToken)
         {
-            var TypeOfCollectionEntity = mapper.Map<TypeOfCollectionEntity>(request.Request);
-            var result = await TypeOfCollectionDomainTypeOfCollection.CreateAsync(TypeOfCollectionEntity);
-            if (!result.IsSuccess)
-                return result.Error!;
+            var validationResult = await validator.ValidateAsync(request.Request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
-            return result.Value!;
+            var TypeOfCollectionEntity = mapper.Map<TypeOfCollectionEntity>(request.Request);
+                var result = await TypeOfCollectionDomainTypeOfCollection.CreateAsync(TypeOfCollectionEntity);
+                if (!result.IsSuccess)
+                    return result.Error!;
+
+                return result.Value!;
         }
     }

--- a/Poliedro.Eds.Application/TypeOfCollection/Commands/UpdateTypeOfCollection/UpdateTypeOfCollectionCommandHandler.cs
+++ b/Poliedro.Eds.Application/TypeOfCollection/Commands/UpdateTypeOfCollection/UpdateTypeOfCollectionCommandHandler.cs
@@ -1,25 +1,33 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.TypeOfCollection.DomainTypeOfCollection;
 using Poliedro.Eds.Domain.TypeOfCollection.Entities;
+using System.Net;
 
 namespace Poliedro.Eds.Application.TypeOfCollection.Commands.UpdateTypeOfCollection;
 
     public class UpdateTypeOfCollectionCommandHandler(
         ITypeOfCollectionUpdateTypeOfCollection TypeOfCollectionDomainTypeOfCollection,
-        IMapper mapper
-    ) : IRequestHandler<UpdateTypeOfCollectionCommand, Result<VoidResult, Error>>
+        IMapper mapper,
+        IValidator<UpdateTypeOfCollectionCommand> validator
+        ) : IRequestHandler<UpdateTypeOfCollectionCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(UpdateTypeOfCollectionCommand request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+                return Result<VoidResult, Error>.Failure(
+                    Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+
             var TypeOfCollectionEntity = mapper.Map<TypeOfCollectionEntity>(request);
-            var result = await TypeOfCollectionDomainTypeOfCollection.UpdateAsync(TypeOfCollectionEntity);
+                var result = await TypeOfCollectionDomainTypeOfCollection.UpdateAsync(TypeOfCollectionEntity);
 
-            if (!result.IsSuccess)
-                return result.Error!;
+                if (!result.IsSuccess)
+                    return result.Error!;
 
-            return result.Value!;
+                return result.Value!;
         }
     }

--- a/Poliedro.Eds.Application/TypeOfCollection/Queries/GetTypeOfCollectionById/GetTypeOfCollectionByIdQueryHandler.cs
+++ b/Poliedro.Eds.Application/TypeOfCollection/Queries/GetTypeOfCollectionById/GetTypeOfCollectionByIdQueryHandler.cs
@@ -1,23 +1,32 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using MediatR;
 using Poliedro.Eds.Application.TypeOfCollection.Dtos;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.TypeOfCollection.DomainTypeOfCollection;
+using System.Net;
 
 namespace Poliedro.Eds.Application.TypeOfCollection.Queries.GetTypeOfCollectionById;
 
     public class GetTypeOfCollectionByIdQueryHandler(
         ITypeOfCollectionGetByIdTypeOfCollection TypeOfCollectionDomainTypeOfCollection,
-        IMapper mapper)
+        IMapper mapper,
+        IValidator<GetTypeOfCollectionByIdQuery> validator)
         : IRequestHandler<GetTypeOfCollectionByIdQuery, Result<TypeOfCollectionDto, Error>>
     {
         public async Task<Result<TypeOfCollectionDto, Error>> Handle(GetTypeOfCollectionByIdQuery request, CancellationToken cancellationToken)
         {
+            var validationResult = await validator.ValidateAsync(request);
+            if (!validationResult.IsValid)
+            {
+                return Result<TypeOfCollectionDto, Error>.Failure(
+                Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
+            }
             var result = await TypeOfCollectionDomainTypeOfCollection.GetByIdAsync(request.Id);
-            if (!result.IsSuccess)
-                return result.Error!;
+                if (!result.IsSuccess)
+                    return result.Error!;
 
-            return mapper.Map<TypeOfCollectionDto>(result.Value);
+                return mapper.Map<TypeOfCollectionDto>(result.Value);
         }
     }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Migrate all request validation out of ASP.NET controllers and into MediatR handlers using FluentValidation, clean up controller actions by removing validator dependencies and inline validation code, and standardize error responses by extending the Result.Match extension to handle failures.

Enhancements:
- Move request validation from controllers into MediatR handlers via injected IValidator<T>
- Remove FluentValidation dependencies and commented validation code from controller methods
- Add validation logic at the start of each command/query handler to return BadRequest on failure
- Update Result.Match extension to accept an onFailure delegate for unified error handling