### PR TITLE
Add deploy_QA job to AWS workflow for ECS deployment and service stat…

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -161,7 +161,7 @@ jobs:
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME_EDS }}/${{ secrets.DOCKERHUB_REPOSITORY_EDS }}:buildcache  
           cache-to: type=inline               
 
-  deploy:
+  deploy_Dev:
     if: github.event.pull_request.merged == true
     needs: docker
     runs-on: ubuntu-latest
@@ -208,3 +208,51 @@ jobs:
             --query 'taskDefinition.containerDefinitions[0].image' --output text)
           
           echo "Imagen de la task definition: $task_definition_image"
+
+  deploy_QA:
+    if: github.event.pull_request.merged == true
+    needs: docker
+    runs-on: ubuntu-latest
+    environment: QA
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Deploy to Amazon ECS
+        run: |
+          # Usar el ARN de la task definition desde Secrets
+          ecs_task_definition_arn="${{ secrets.TASK_DEFINITION_ARN_EDS_QA }}"
+          echo "Usando el ARN de la task definition: $ecs_task_definition_arn"
+          
+          # Forzar la actualización del servicio con la task definition existente
+          ecs_deploy=$(aws ecs update-service \
+            --cluster ${{ secrets.AWS_ECS_CLUSTER }} \
+            --service ${{ secrets.AWS_ECS_SERVICE_EDS_QA }} \
+            --task-definition $ecs_task_definition_arn \
+            --force-new-deployment)
+          
+          echo "Resultado del despliegue en ECS: $ecs_deploy"
+
+      - name: Check ECS Service Status
+        run: |
+          echo "Verificando estado del servicio ECS..."
+          service_status=$(aws ecs describe-services \
+            --cluster ${{ secrets.AWS_ECS_CLUSTER }} \
+            --services ${{ secrets.AWS_ECS_SERVICE_EDS_QA }} \
+            --query 'services[0].status' --output text)
+          
+          echo "Estado del servicio: $service_status"
+
+      - name: Check ECS Task Definition
+        run: |
+          echo "Verificando imagen de la task definition..."
+          task_definition_image=$(aws ecs describe-task-definition \
+            --task-definition ${{ secrets.TASK_DEFINITION_ARN_EDS_QA }} \
+            --query 'taskDefinition.containerDefinitions[0].image' --output text)
+          
+          echo "Imagen de la task definition: $task_definition_image"        


### PR DESCRIPTION
…us checks

### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Update AWS GitHub Actions workflow to rename the Dev deploy job and introduce a QA deployment job that performs ECS service updates and status checks.

Enhancements:
- Rename existing deploy job to deploy_Dev
- Add deploy_QA job for ECS deployment to QA environment with service and task definition checks

CI:
- Rename deploy job and introduce QA deployment job in AWS GitHub Actions workflow