### PR TITLE
Revert "Merge pull request #67 from PoliedroSoftware/HU-1121-BugCourt…

### DIFF
--- a/Poliedro.Eds.Api/Controllers/v1/Hose/HoseController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Hose/HoseController.cs
@@ -1,5 +1,4 @@
-﻿using AutoMapper;
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Poliedro.Eds.Api.Common.Extensions;
@@ -28,8 +27,6 @@ namespace Poliedro.Eds.Api.Controllers.v1.Hose
             var data = await mediator.Send(new GellAllHoseQuery(new PaginationParams { PageNumber = paginationParams.PageNumber, PageSize = paginationParams.PageSize }));
             if (data is null)
             {
-               // new PaginationParams { PageNumber = paginationParams.PageNumber, PageSize = paginationParams.PageSize };
-
                 return StatusCode(StatusCodes.Status404NotFound, ResponseApiService.Response(StatusCodes.Status404NotFound));
             }
             return StatusCode(StatusCodes.Status200OK, ResponseApiService.Response(StatusCodes.Status200OK, data));
@@ -116,3 +113,4 @@ namespace Poliedro.Eds.Api.Controllers.v1.Hose
         }
     }
 }
+

--- a/Poliedro.Eds.Domain/Court/Entities/View/HoseViewEntity.cs
+++ b/Poliedro.Eds.Domain/Court/Entities/View/HoseViewEntity.cs
@@ -1,31 +1,8 @@
 public class HoseViewEntity
 {
-    public int IdHose { get; set; }
-    public int HoseNumber { get; set; }
-    public int Dispenser { get; set; }
-    public double AccumulatedGallons { get; set; }
-    public double AccumulatedAmount { get; set; }
-    public int ProductType { get; set; }
-    public double Price { get; set; }
-
-    // Dispenser details
-    public int IdDispenser { get; set; }
-    public string Code { get; set; } = string.Empty;
-    public int Number { get; set; }
-    public int IdDispenserType { get; set; }
-    public int IdEds { get; set; }
-    public int IdIsland { get; set; }
+    public int Id { get; set; }
     public int NumberHose { get; set; }
-
-    // Product Type details
-    public int IdProductType { get; set; }
-    public string Description { get; set; } = string.Empty;
-
-    // Eds details
-    public int EdsId { get; set; }
-    public string Name { get; set; } = string.Empty;
-    public string Nit { get; set; } = string.Empty;
-    public string Address { get; set; } = string.Empty;
-    public string Sicom { get; set; } = string.Empty;
-    public int IdBusiness { get; set; }
+    public double AccumulatedAmount { get; set; }
+    public double AccumulatedGallons { get; set; }
+    public string ProductType { get; set; }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
@@ -1,126 +1,58 @@
 ﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Internal;
 using Poliedro.Eds.Application.Ports.Redis;
 using Poliedro.Eds.Domain.Common.Pagination;
-using Poliedro.Eds.Domain.Dispensers.Entities;
-using Poliedro.Eds.Domain.Eds.Entities;
 using Poliedro.Eds.Domain.Hose.DomainHose;
 using Poliedro.Eds.Domain.Hose.Dtos;
-using Poliedro.Eds.Domain.ProductType.Entities;
 using Poliedro.Eds.Infraestructure.Persistence.Mysql.Context;
-using System.Data;
 
 namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Hose.DomainHose.Impl;
 
-
-
 public class HoseGetAllHose(
-ITenantDbContextFactory dbContextFactory,
-IRedisService redisService,
-IHttpContextAccessor httpContextAccessor
-) : IHoseGetAllHose
-{   
-    public async Task<IEnumerable<HoseViewDto>> GetAllAsync(PaginationParams paginationParams)
+    ITenantDbContextFactory dbContextFactory,
+    IRedisService redisService,
+    IHttpContextAccessor httpContextAccessor
+    ) : IHoseGetAllHose
+{
+    public async Task<IEnumerable<HoseDto>> GetAllAsync(PaginationParams paginationParams)
     {
+
         var tenant = httpContextAccessor.HttpContext?.Items["tenant"]?.ToString();
-        string cacheKey = $"hoseListService:{paginationParams.PageNumber}:{paginationParams.PageSize}:{tenant}";
+        string cacheKey = $"hose:{paginationParams.PageNumber}:{paginationParams.PageSize}:{tenant}";
 
-        var cachedData = await redisService.GetCacheAsync<IEnumerable<HoseViewDto>>(cacheKey);
-        if (cachedData != null) return cachedData;
+        var cachedDtos = await redisService.GetCacheAsync<IEnumerable<HoseDto>>(cacheKey);
+        if (cachedDtos is not null)
+            return cachedDtos;
 
-        try
-        {
-            var hoses = await GetHosesFromViewAsync();
+        using var context = dbContextFactory.CreateDbContext();
 
-            var pagedHoses = hoses
-                .OrderByDescending(h => h.IdHose)
-                .Skip((paginationParams.PageNumber - 1) * paginationParams.PageSize)
-                .Take(paginationParams.PageSize)
-                .ToList();
+        var query = from hose in context.Hose
+                    join dispenser in context.Dispensers on hose.IdDispensers equals dispenser.Id
+                    join productType in context.ProductTypes on hose.IdProductType equals productType.IdProductType
+                    join eds in context.Eds on dispenser.EdsId equals eds.IdEds
+                    join product in context.Product on hose.IdProductType equals product.IdProductType
 
-            await redisService.SetCacheAsync(cacheKey, pagedHoses, TimeSpan.FromMinutes(1440));
-            return pagedHoses;
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"ERROR en GetAllAsync: {ex.Message}\n{ex.StackTrace}");
-            throw;
-        }
+                    select new HoseDto(
+                        hose.IdHose,
+                        hose.Number,
+                        hose.IdDispensers,
+                        hose.AccumulatedGallons,
+                        hose.AccumulatedAmount,
+                        hose.IdProductType,
+                        product.Price,
+                        dispenser,
+                        productType,
+                        eds
+                    );
+
+        var hoseDtos = await query
+            .Skip((paginationParams.PageNumber - 1) * paginationParams.PageSize)
+            .Take(paginationParams.PageSize)
+            .ToListAsync();
+
+        await redisService.SetCacheAsync(cacheKey, hoseDtos, TimeSpan.FromMinutes(1440));
+
+        return hoseDtos;
     }
-
-    public async Task<IEnumerable<HoseViewDto>> GetHosesFromViewAsync()
-    {
-        try
-        {
-            using var context = dbContextFactory.CreateDbContext();
-            var hoses = new List<HoseViewDto>();
-            using var connection = context.Database.GetDbConnection();
-            await connection.OpenAsync();
-
-            string query = "SELECT * FROM v_hose_list";
-            using var command = connection.CreateCommand();
-            command.CommandText = query;
-
-            using var reader = await command.ExecuteReaderAsync();
-
-            while (await reader.ReadAsync())
-            {
-                hoses.Add(new HoseViewDto
-                {
-                    IdHose = reader.GetInt32(reader.GetOrdinal("id_hose")),
-                    HoseNumber = reader.GetInt32(reader.GetOrdinal("hose_number")),
-                    Dispenser = reader.GetInt32(reader.GetOrdinal("dispenser")),
-                    AccumulatedGallons = reader.GetDouble(reader.GetOrdinal("accumulated_gallons")),
-                    AccumulatedAmount = reader.GetDouble(reader.GetOrdinal("accumulated_amount")),
-                    ProductType = reader.GetInt32(reader.GetOrdinal("product_type")),
-                    Price = reader.GetDouble(reader.GetOrdinal("price")),
-
-                    IdDispenser = reader.GetInt32(reader.GetOrdinal("id_dispensers")),
-                    Code = reader.GetString(reader.GetOrdinal("code")),
-                    Number = reader.GetInt32(reader.GetOrdinal("number")),
-                    IdDispenserType = reader.GetInt32(reader.GetOrdinal("id_dispenser_type")),
-                    IdEds = reader.GetInt32(reader.GetOrdinal("id_eds")),
-                    IdIsland = reader.GetInt32(reader.GetOrdinal("idisland")),
-                    NumberHose = reader.GetInt32(reader.GetOrdinal("number_hose")),
-
-                    IdProductType = reader.GetInt32(reader.GetOrdinal("id_product_type")),
-                    Description = reader.GetString(reader.GetOrdinal("description")),
-
-                    EdsId = reader.GetInt32(reader.GetOrdinal("dispensers")),
-                    Name = reader.GetString(reader.GetOrdinal("name")),
-                    Nit = reader.GetString(reader.GetOrdinal("nit")),
-                    Address = reader.GetString(reader.GetOrdinal("address")),
-                    Sicom = reader.GetString(reader.GetOrdinal("sicom")),
-                    IdBusiness = reader.GetInt32(reader.GetOrdinal("idbusiness"))
-                });
-            }
-
-            return hoses;
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"ERROR en GetHosesFromViewAsync: {ex.Message}\n{ex.StackTrace}");
-            throw;
-        }
-    }
-    async Task<IEnumerable<HoseDto>> IHoseGetAllHose.GetAllAsync(PaginationParams paginationParams)
-    {
-        var result = await GetAllAsync(paginationParams);
-        return result.Select(h => new HoseDto(
-            h.IdHose,
-            h.Number,
-            h.IdDispenser,
-            h.AccumulatedGallons,
-            h.AccumulatedAmount,
-            h.IdProductType,
-            h.Price,
-            new DispensersEntity(), 
-            new ProductTypeEntity(),
-            new EdsEntity()
-        ));
-    }
-
 
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/IApplicationDbContextFactory.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/IApplicationDbContextFactory.cs
@@ -1,7 +1,0 @@
-﻿namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Hose.DomainHose.Impl
-{
-    internal interface IApplicationDbContextFactory
-    {
-        object CreateDbContext();
-    }
-}


### PR DESCRIPTION
…Get"

This reverts commit a26d5be4955592b00027f7bdfb96273506036aab, reversing changes made to aa1f5f445e7c719a2a2bbf94728a879b418783d5.

Revert "Merge pull request #67 from PoliedroSoftware/HU-1121-BugCourtGet"

This reverts commit a26d5be4955592b00027f7bdfb96273506036aab, reversing changes made to 357dcf329311307f20ee1c2b7a3fda3a90391a0f.

### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Revert the previous BugCourtGet merge by restoring the original EF-based hose retrieval and mapping, simplifying the hose view entity, cleaning up the controller, and removing an unused interface.

Enhancements:
- Restore HoseGetAllHose to use EF Core LINQ joins for data retrieval instead of raw SQL view queries and manual mapping
- Simplify HoseViewEntity to include only core hose fields
- Remove unused IApplicationDbContextFactory interface
- Clean up HoseController by removing unused usings and stray comments