### PR TITLE
Correction bug HoseGetAllHose

### DIFF
--- a/Poliedro.Eds.Domain/Hose/Dtos/HoseDto.cs
+++ b/Poliedro.Eds.Domain/Hose/Dtos/HoseDto.cs
@@ -4,15 +4,40 @@ using Poliedro.Eds.Domain.ProductType.Entities;
 
 namespace Poliedro.Eds.Domain.Hose.Dtos;
 
-public record HoseDto(
-    int IdHose,
-    int Number,
-    int IdDispensers,
-    double AccumulatedGallons,
-    double AccumulatedAmount,
-    int IdProductType,
-    double Price,
-    DispensersEntity dispensersEntity,
-    ProductTypeEntity productTypeEntity,
-    EdsEntity edsEntity
-);
+public record HoseDto
+{
+    public HoseDto(object idHose, object number, object idDispenser, object accumulatedGallons, object accumulatedAmount, object idProductType, object price, DispensersEntity dispensersEntity, ProductTypeEntity productTypeEntity, EdsEntity edsEntity)
+    {
+        IdHose1 = idHose;
+        Number1 = number;
+        IdDispenser = idDispenser;
+        AccumulatedGallons1 = accumulatedGallons;
+        AccumulatedAmount1 = accumulatedAmount;
+        IdProductType1 = idProductType;
+        Price1 = price;
+        DispensersEntity1 = dispensersEntity;
+        ProductTypeEntity1 = productTypeEntity;
+        EdsEntity1 = edsEntity;
+    }
+
+    public int IdHose { get; init; }
+    public int Number { get; init; }
+    public int IdDispensers { get; init; }
+    public double AccumulatedGallons { get; init; }
+    public double AccumulatedAmount { get; init; }
+    public int IdProductType { get; init; }
+    public double Price { get; init; }
+    public DispensersEntity DispensersEntity { get; init; }
+    public ProductTypeEntity ProductTypeEntity { get; init; }
+    public EdsEntity EdsEntity { get; init; }
+    public object IdHose1 { get; }
+    public object Number1 { get; }
+    public object IdDispenser { get; }
+    public object AccumulatedGallons1 { get; }
+    public object AccumulatedAmount1 { get; }
+    public object IdProductType1 { get; }
+    public object Price1 { get; }
+    public DispensersEntity DispensersEntity1 { get; }
+    public ProductTypeEntity ProductTypeEntity1 { get; }
+    public EdsEntity EdsEntity1 { get; }
+}

--- a/Poliedro.Eds.Domain/Hose/Dtos/HoseDto.cs
+++ b/Poliedro.Eds.Domain/Hose/Dtos/HoseDto.cs
@@ -4,40 +4,15 @@ using Poliedro.Eds.Domain.ProductType.Entities;
 
 namespace Poliedro.Eds.Domain.Hose.Dtos;
 
-public record HoseDto
-{
-    public HoseDto(object idHose, object number, object idDispenser, object accumulatedGallons, object accumulatedAmount, object idProductType, object price, DispensersEntity dispensersEntity, ProductTypeEntity productTypeEntity, EdsEntity edsEntity)
-    {
-        IdHose1 = idHose;
-        Number1 = number;
-        IdDispenser = idDispenser;
-        AccumulatedGallons1 = accumulatedGallons;
-        AccumulatedAmount1 = accumulatedAmount;
-        IdProductType1 = idProductType;
-        Price1 = price;
-        DispensersEntity1 = dispensersEntity;
-        ProductTypeEntity1 = productTypeEntity;
-        EdsEntity1 = edsEntity;
-    }
-
-    public int IdHose { get; init; }
-    public int Number { get; init; }
-    public int IdDispensers { get; init; }
-    public double AccumulatedGallons { get; init; }
-    public double AccumulatedAmount { get; init; }
-    public int IdProductType { get; init; }
-    public double Price { get; init; }
-    public DispensersEntity DispensersEntity { get; init; }
-    public ProductTypeEntity ProductTypeEntity { get; init; }
-    public EdsEntity EdsEntity { get; init; }
-    public object IdHose1 { get; }
-    public object Number1 { get; }
-    public object IdDispenser { get; }
-    public object AccumulatedGallons1 { get; }
-    public object AccumulatedAmount1 { get; }
-    public object IdProductType1 { get; }
-    public object Price1 { get; }
-    public DispensersEntity DispensersEntity1 { get; }
-    public ProductTypeEntity ProductTypeEntity1 { get; }
-    public EdsEntity EdsEntity1 { get; }
-}
+    public record HoseDto(
+        int IdHose,
+        int Number,
+        int IdDispensers,
+        double AccumulatedGallons,
+        double AccumulatedAmount,
+        int IdProductType,
+        double Price,
+        DispensersEntity DispensersEntity,
+        ProductTypeEntity ProductTypeEntity,
+        EdsEntity EdsEntity
+    );

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
@@ -11,10 +11,9 @@ using Poliedro.Eds.Domain.Hose.Dtos;
 using Poliedro.Eds.Domain.ProductType.Entities;
 using Poliedro.Eds.Infraestructure.Persistence.Mysql.Context;
 using System.Data;
+using System.Linq;
 
 namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Hose.DomainHose.Impl;
-
-
 
 public class HoseGetAllHose(
 ITenantDbContextFactory dbContextFactory,
@@ -105,6 +104,7 @@ IHttpContextAccessor httpContextAccessor
             throw;
         }
     }
+
     async Task<IEnumerable<HoseDto>> IHoseGetAllHose.GetAllAsync(PaginationParams paginationParams)
     {
         var result = await GetAllAsync(paginationParams);
@@ -121,6 +121,4 @@ IHttpContextAccessor httpContextAccessor
             new EdsEntity()
         ));
     }
-
-
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
@@ -109,16 +109,16 @@ IHttpContextAccessor httpContextAccessor
     {
         var result = await GetAllAsync(paginationParams);
         return result.Select(h => new HoseDto(
-            h.IdHose,
-            h.Number,
-            h.IdDispenser,
-            h.AccumulatedGallons,
-            h.AccumulatedAmount,
-            h.IdProductType,
-            h.Price,
-            new DispensersEntity(), 
-            new ProductTypeEntity(),
-            new EdsEntity()
-        ));
+     Convert.ToInt32(h.IdHose),
+     Convert.ToInt32(h.Number),
+     Convert.ToInt32(h.IdDispenser),
+     Convert.ToDouble(h.AccumulatedGallons),
+     Convert.ToDouble(h.AccumulatedAmount),
+     Convert.ToInt32(h.IdProductType),
+     Convert.ToDouble(h.Price),
+     new DispensersEntity(),
+     new ProductTypeEntity(),
+     new EdsEntity()
+ ));
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseViewDto.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseViewDto.cs
@@ -1,0 +1,32 @@
+﻿using Poliedro.Eds.Domain.Dispensers.Entities;
+using Poliedro.Eds.Domain.Eds.Entities;
+using Poliedro.Eds.Domain.ProductType.Entities;
+
+namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Hose.DomainHose.Impl
+{
+    public class HoseViewDto
+    {
+        public object IdHose { get; internal set; }
+        public object HoseNumber { get; internal set; }
+        public object Dispenser { get; internal set; }
+        public object AccumulatedGallons { get; internal set; }
+        public object AccumulatedAmount { get; internal set; }
+        public object ProductType { get; internal set; }
+        public object Price { get; internal set; }
+        public object IdDispenser { get; internal set; }
+        public object Code { get; internal set; }
+        public object Number { get; internal set; }
+        public object IdDispenserType { get; internal set; }
+        public object IdEds { get; internal set; }
+        public object IdIsland { get; internal set; }
+        public object NumberHose { get; internal set; }
+        public object IdProductType { get; internal set; }
+        public object Description { get; internal set; }
+        public object EdsId { get; internal set; }
+        public object Name { get; internal set; }
+        public object Nit { get; internal set; }
+        public object Address { get; internal set; }
+        public object Sicom { get; internal set; }
+        public object IdBusiness { get; internal set; }
+    }
+}


### PR DESCRIPTION
### Checklist antes de hacer merge

- [x] Code compiles correctly  
- [x] Tests have been added  
- [x] Documentation has been updated  
- [x] Team has been informed about the changes

## Summary by Sourcery

Fix hose retrieval mapping in HoseGetAllHose by restructuring DTOs and adding a dedicated view DTO

Bug Fixes:
- Correct the mapping logic in HoseGetAllHose by redefining DTO constructors and property types to resolve type mismatches

Enhancements:
- Convert HoseDto from a positional record to a class with explicit typed properties and a custom constructor for proper data assignment
- Add a new HoseViewDto class to represent fields returned by the hose database view

Chores:
- Add missing System.Linq import and clean up formatting in HoseGetAllHose implementation