### PR TITLE
correction bug

### DIFF
--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Hose/DomainHose/Impl/HoseGetAllHose.cs
@@ -26,29 +26,36 @@ public class HoseGetAllHose(
 
         using var context = dbContextFactory.CreateDbContext();
 
+        var validIds = await context.Hose.Select(h => h.IdHose).ToListAsync();
+
         var query = from hose in context.Hose
+                    where validIds.Contains(hose.IdHose)
                     join dispenser in context.Dispensers on hose.IdDispensers equals dispenser.Id
                     join productType in context.ProductTypes on hose.IdProductType equals productType.IdProductType
                     join eds in context.Eds on dispenser.EdsId equals eds.IdEds
                     join product in context.Product on hose.IdProductType equals product.IdProductType
-
+                    group new { hose, dispenser, productType, eds, product } by hose.IdHose into g
                     select new HoseDto(
-                        hose.IdHose,
-                        hose.Number,
-                        hose.IdDispensers,
-                        hose.AccumulatedGallons,
-                        hose.AccumulatedAmount,
-                        hose.IdProductType,
-                        product.Price,
-                        dispenser,
-                        productType,
-                        eds
+                        g.First().hose.IdHose,
+                        g.First().hose.Number,
+                        g.First().hose.IdDispensers,
+                        g.First().hose.AccumulatedGallons,
+                        g.First().hose.AccumulatedAmount,
+                        g.First().hose.IdProductType,
+                        g.First().product.Price,
+                        g.First().dispenser,
+                        g.First().productType,
+                        g.First().eds
                     );
 
-        var hoseDtos = await query
+        var hoseDtos = (await query
+            .ToListAsync())
+            .GroupBy(h => h.IdHose)
+            .Select(g => g.First())
             .Skip((paginationParams.PageNumber - 1) * paginationParams.PageSize)
             .Take(paginationParams.PageSize)
-            .ToListAsync();
+            .ToList();
+
 
         await redisService.SetCacheAsync(cacheKey, hoseDtos, TimeSpan.FromMinutes(1440));
 


### PR DESCRIPTION
### Checklist antes de hacer merge

- [x] Code compiles correctly  
- [x] Tests have been added  
- [x] Documentation has been updated  
- [x] Team has been informed about the changes

## Summary by Sourcery

Revise GetAllAsync to properly group and paginate Hose records: fetch valid IDs, apply grouping and DTO projection from grouped results, then paginate in-memory before caching.

Bug Fixes:
- Fix DTO projection to reference the first element of each grouping when constructing HoseDto
- Correct pagination and duplicate elimination by grouping in-memory instead of relying on SQL-level pagination

Enhancements:
- Add initial retrieval of valid hose IDs to filter the main query