### PR TITLE
feat(enum): add enum for shopping and sell and court

### DIFF
--- a/Poliedro.Eds.Application/Court/Commands/CreateCourt/Handler/CreateCourtCommandHandle.cs
+++ b/Poliedro.Eds.Application/Court/Commands/CreateCourt/Handler/CreateCourtCommandHandle.cs
@@ -6,6 +6,7 @@ using Poliedro.Eds.Application.Common.Constants;
 using Poliedro.Eds.Application.Common.Helper.removekey;
 using Poliedro.Eds.Application.Court.Dtos;
 using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Domain.Common.Enums;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Court.DomainService;
@@ -81,7 +82,7 @@ namespace Poliedro.Eds.Application.Court.Commands.CreateCourt.Handler
             courtEntity.CourtInventory = new InventoryEntity
             {
                 Date = courtEntity.DateStarttime,
-                ReferenceType = "court",
+                ReferenceType = ReferenceType.Court,
             };
 
             var result = await courtDomainService.CreateAsync(courtEntity);

--- a/Poliedro.Eds.Application/Shopping/Commands/CreateShopping/CreateShoppingCommandHandler.cs
+++ b/Poliedro.Eds.Application/Shopping/Commands/CreateShopping/CreateShoppingCommandHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Poliedro.Eds.Application.Common.Constants;
 using Poliedro.Eds.Application.Common.Helper.removekey;
 using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Domain.Common.Enums;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Inventory.Entities;
@@ -32,7 +33,7 @@ public class CreateShoppingCommandHandler(
         shoppingEntity.ShoppingInventory = new InventoryEntity
         {
             Date = DateOnly.FromDateTime(shoppingEntity.Date),
-            ReferenceType = "shopping",
+            ReferenceType = ReferenceType.Shopping,
         };
 
         var productsToUpdatePrice = request.Request.ShoppingProducts

--- a/Poliedro.Eds.Application/Shopping/Dtos/ShoppingInventoryDto.cs
+++ b/Poliedro.Eds.Application/Shopping/Dtos/ShoppingInventoryDto.cs
@@ -1,9 +1,11 @@
+using Poliedro.Eds.Domain.Common.Enums;
+
 namespace Poliedro.Eds.Application.Shopping.Dtos;
 
 public record ShoppingInventoryDto
 (
     int IdInventory,
     DateOnly Date,
-    string ReferenceType,
+    ReferenceType ReferenceType,
     int ReferenceId
 );

--- a/Poliedro.Eds.Domain/Common/Enums/ReferenceType.cs
+++ b/Poliedro.Eds.Domain/Common/Enums/ReferenceType.cs
@@ -1,0 +1,8 @@
+namespace Poliedro.Eds.Domain.Common.Enums;
+
+public enum ReferenceType
+{
+    Shopping,
+    Sale,
+    Court
+}

--- a/Poliedro.Eds.Domain/Inventory/Entities/InventoryEntity.cs
+++ b/Poliedro.Eds.Domain/Inventory/Entities/InventoryEntity.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Poliedro.Eds.Domain.Audit.Entities;
+using Poliedro.Eds.Domain.Common.Enums;
 
 namespace Poliedro.Eds.Domain.Inventory.Entities;
 
@@ -8,6 +9,6 @@ public class InventoryEntity : AuditableEntity
     [Key]
     public int IdInventory { get; set; }
     public DateOnly Date { get; set; }
-    public string ReferenceType { get; set; }
+    public ReferenceType ReferenceType { get; set; }
     public int ReferenceId { get; set; }
 }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [x] Code compiles correctly  
- [x] Tests have been added  
- [x] Documentation has been updated  
- [x] Team has been informed about the changes

## Summary by Sourcery

Introduce a strongly-typed ReferenceType enum for shopping, sale, and court and refactor inventory-related models and handlers to use it instead of string literals.

Enhancements:
- Add ReferenceType enum with values Shopping, Sale, and Court
- Replace string ReferenceType properties with the new enum type in InventoryEntity and ShoppingInventoryDto
- Update CreateShopping and CreateCourt command handlers to assign enum values rather than string literals