### PR TITLE
Remove stock

### DIFF
--- a/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentCommandValidator.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentCommandValidator.cs
@@ -17,11 +17,9 @@ public class CreateCompartimentCommandValidator : AbstractValidator<CreateCompar
             .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("NominalGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
         RuleFor(x => x.Operative)
-            .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult())
-            .LessThanOrEqualTo(x => x.Stock).WithMessage(redisService.GetValueFromCacheAsync("OperativeLessThanOrEqualTo").GetAwaiter().GetResult());
+            .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult());
+            
 
-        RuleFor(x => x.Stock)
-            .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("StockGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
         RuleFor(x => x.Height)
             .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("HeightGreaterThanOrEqualTo").GetAwaiter().GetResult());

--- a/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentRequestDto.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentRequestDto.cs
@@ -4,7 +4,7 @@ public record CreateCompartimentRequestDto(
     int Number,
     double Nominal,
     double Operative,
-    double Stock,
+    double? Stock,
     double Height,
     int IdTank);
 

--- a/Poliedro.Eds.Domain/Compartiment/Entities/CompartimentEntity.cs
+++ b/Poliedro.Eds.Domain/Compartiment/Entities/CompartimentEntity.cs
@@ -8,7 +8,7 @@ public class CompartimentEntity : AuditableEntity
     public int Number { get; set; }
     public double Nominal { get; set; }
     public double Operative { get; set; }
-    public double Stock { get; set; }
+    public double? Stock { get; set; }
     public double Height { get; set; }
     public int IdTank { get; set; }
 }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Make the Stock field optional in the Compartiment workflow by converting its type to nullable and removing all related validation rules

Enhancements:
- Change Stock property to nullable in CreateCompartimentRequestDto and CompartimentEntity
- Remove the Stock >= 0 rule and the Operative ≤ Stock constraint from CreateCompartimentCommandValidator