### PR TITLE
fix(tank): change property stok for null

### DIFF
--- a/Poliedro.Eds.Application/Tank/Commands/CreateTank/CreateTankCommandValidator.cs
+++ b/Poliedro.Eds.Application/Tank/Commands/CreateTank/CreateTankCommandValidator.cs
@@ -20,9 +20,5 @@ public class CreateTankCommandValidator : AbstractValidator<CreateTankRequestDto
             .NotNull().WithMessage(redisService.GetValueFromCacheAsync("AbilityNotNull").GetAwaiter().GetResult())
             .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("AbilityGreaterThan").GetAwaiter().GetResult());
 
-        RuleFor(x => x.Stock)
-            .NotNull().WithMessage(redisService.GetValueFromCacheAsync("StockNotNull").GetAwaiter().GetResult())
-            .GreaterThan(0.0).WithMessage(redisService.GetValueFromCacheAsync("StockGreaterThan").GetAwaiter().GetResult());
-
     }
 }

--- a/Poliedro.Eds.Application/Tank/Commands/CreateTank/CreateTankRequestDto.cs
+++ b/Poliedro.Eds.Application/Tank/Commands/CreateTank/CreateTankRequestDto.cs
@@ -4,6 +4,6 @@ public record CreateTankRequestDto(
     string Number,
     int Compartment,
     double Ability,
-    double Stock);
+    double? Stock);
 
 

--- a/Poliedro.Eds.Domain/Tank/Entities/TankEntity.cs
+++ b/Poliedro.Eds.Domain/Tank/Entities/TankEntity.cs
@@ -10,6 +10,6 @@ public class TankEntity : AuditableEntity
     public string Number { get; set; }
     public int Compartment { get; init; }
     public double Ability { get; init; }
-    public double Stock { get; init; }
+    public double? Stock { get; init; }
 
 }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Allow Stock to be optional by making its type nullable and removing its validation

Bug Fixes:
- Change Stock property to nullable in DTO and entity
- Remove Stock validation rules in CreateTankCommandValidator