### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,5 +1,8 @@
 name: Build, Test, Deploy to ECS
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/PoliedroSoftware/backend-api-eds/security/code-scanning/19](https://github.com/PoliedroSoftware/backend-api-eds/security/code-scanning/19)

To address this issue, add an explicit `permissions` block to the workflow. This block should be placed at the root level of the workflow file, right after the `name` field and before `on`. As a minimal and safest starting point, set `permissions` to `contents: read` (which is sufficient for nearly all build/test/deploy flows and the default recommended by GitHub). If any jobs in the workflow (or the reusable workflows called by this one) require greater permissions for specific scopes (e.g., `pull-requests: write`), such permissions should be added **only for those jobs**. However, as nothing in the provided workflow indicates a need for more than read access (no jobs interact with PRs using the API, etc.), the root-level `permissions: contents: read` is an appropriate default.

Specifically, in `.github/workflows/aws.yml`, insert:
```yaml
permissions:
  contents: read
```
after the `name:` field and before `on:`.

No additional imports or methods are necessary for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enhancements:
- Insert a root-level permissions block granting contents: read in the AWS workflow