### PR TITLE
Potential fix for code scanning alert no. 16: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -65,22 +65,12 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}             
       
-  deploy:
+  deploy-dev:
     if: github.event.pull_request.merged == true
     needs: docker
-    strategy:
-      matrix:
-        environment: [dev, qa]
-        include:
-          - environment: dev
-            service_secret: AWS_ECS_SERVICE
-            task_definition_secret: TASK_DEFINITION_ARN
-          - environment: qa
-            service_secret: AWS_ECS_SERVICE_EDS_QA
-            task_definition_secret: TASK_DEFINITION_ARN_EDS_QA
     uses: ./.github/workflows/reusable-aws-deploy.yml
     with:
-      environment: ${{ matrix.environment }}
+      environment: dev
       aws-region: ${{ vars.AWS_REGION || 'us-east-2' }}
       wait-for-deployment: true
       deployment-timeout: '10'
@@ -88,5 +78,21 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_ECS_CLUSTER: ${{ secrets.AWS_ECS_CLUSTER }}
-      AWS_ECS_SERVICE: ${{ secrets[matrix.service_secret] }}
-      TASK_DEFINITION_ARN: ${{ secrets[matrix.task_definition_secret] }}        
+      AWS_ECS_SERVICE: ${{ secrets.AWS_ECS_SERVICE }}
+      TASK_DEFINITION_ARN: ${{ secrets.TASK_DEFINITION_ARN }}
+
+  deploy-qa:
+    if: github.event.pull_request.merged == true
+    needs: docker
+    uses: ./.github/workflows/reusable-aws-deploy.yml
+    with:
+      environment: qa
+      aws-region: ${{ vars.AWS_REGION || 'us-east-2' }}
+      wait-for-deployment: true
+      deployment-timeout: '10'
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ECS_CLUSTER: ${{ secrets.AWS_ECS_CLUSTER }}
+      AWS_ECS_SERVICE: ${{ secrets.AWS_ECS_SERVICE_EDS_QA }}
+      TASK_DEFINITION_ARN: ${{ secrets.TASK_DEFINITION_ARN_EDS_QA }}


### PR DESCRIPTION
Potential fix for [https://github.com/PoliedroSoftware/backend-api-eds/security/code-scanning/16](https://github.com/PoliedroSoftware/backend-api-eds/security/code-scanning/16)

To fix the problem, we should avoid dynamic secret access, and instead, specify all required secrets with direct references. For the `deploy` job, instead of using `${{ secrets[matrix.service_secret] }}` and `${{ secrets[matrix.task_definition_secret] }}`, we can use conditional expressions to pass the correct secrets based on `matrix.environment`. This means splitting the `deploy` job into two: one for `dev` and one for `qa`, each referencing the specific secrets they require (`AWS_ECS_SERVICE`, `TASK_DEFINITION_ARN`, `AWS_ECS_SERVICE_EDS_QA`, and `TASK_DEFINITION_ARN_EDS_QA`). We can accomplish this by using the matrix as-is, but leveraging an `if` statement within an array of job definitions, or more simply, by using two jobs with the appropriate secrets and `if: matrix.environment == ...` guards.

All changes occur in `.github/workflows/aws.yml`, specifically in the `deploy` job definition, lines 68–92. We'll update the job to have one for dev and one for qa, each referencing only the relevant secrets directly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Replace dynamic secret access in the GitHub Actions deploy workflow with explicit secret references by splitting the deploy job into environment-specific jobs for dev and qa to address a code scanning security alert.

Bug Fixes:
- Mitigate excessive secrets exposure by removing dynamic secret interpolation in the deploy job.

Enhancements:
- Split the single deploy job into separate deploy-dev and deploy-qa jobs with direct secret references for each environment.

CI:
- Update .github/workflows/aws.yml to use explicit secrets and environment-specific jobs instead of a matrix strategy.