### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reusable-sonar.yml
+++ b/.github/workflows/reusable-sonar.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Reusable SonarCloud Analysis
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/PoliedroSoftware/backend-api-eds/security/code-scanning/14](https://github.com/PoliedroSoftware/backend-api-eds/security/code-scanning/14)

To fix this issue, add an explicit `permissions` block to restrict the default permissions of the GITHUB_TOKEN to only what’s required—typically `contents: read` suffices for analysis jobs that do not need to push or modify code, issues, or PRs. The best practice is to add this `permissions` block at the top-level of the workflow (just after the `name` or the `on` block), which applies to all jobs unless overridden, or to each job individually if granular control is needed. In this case, add:

```yaml
permissions:
  contents: read
```

after the `name:` line and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add top-level permissions: contents: read to reusable-sonar.yml to restrict default GITHUB_TOKEN permissions