### PR TITLE
fix: (compartiment): error compartiment fixed Ok

### DIFF
--- a/Poliedro.Eds.Api/Controllers/v1/Compartiment/Compartiment.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Compartiment/Compartiment.cs
@@ -67,14 +67,13 @@ public class CompartimentController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOnly")]
     [HttpPost]
-
     public async Task<IResult> Create([FromBody] CreateCompartimentCommand createCompartimentCommand)
-
     {
         var result = await mediator.Send(createCompartimentCommand);
         return result.Match(
-             onSuccess => TypedResults.Created()
-         );
+            onSuccess => TypedResults.Created(),
+            onFailure => TypedResults.BadRequest(onFailure)
+        );
     }
 
     [SwaggerOperation(Summary = "Update an existing Compartiment")]

--- a/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentCommandHandler.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentCommandHandler.cs
@@ -28,7 +28,7 @@ namespace Poliedro.Eds.Application.Compartiment.Commands.CreateCompartiment
 
             var result = await compartimentDomainService.CreateAsync(mapper.Map<CompartimentEntity>(request.Request));
             await RedisHelper.RemoveCacheIfSuccessAsync(result, redisService, KeyRedisConstants.COMPARTIMENT);
-            return result.IsSuccess ? result.Value! : result.Error!;
+            return result;
         }
     }
 }

--- a/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentCommandValidator.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentCommandValidator.cs
@@ -18,8 +18,9 @@ public class CreateCompartimentCommandValidator : AbstractValidator<CreateCompar
 
         RuleFor(x => x.Operative)
             .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult());
-            
 
+        RuleFor(x => x.IdProduct)
+            .GreaterThan(0).WithMessage(redisService.GetValueFromCacheAsync("IdProductGreaterThan").GetAwaiter().GetResult());
 
         RuleFor(x => x.Height)
             .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("HeightGreaterThanOrEqualTo").GetAwaiter().GetResult());

--- a/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentRequestDto.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/CreateServer/CreateCompartimentRequestDto.cs
@@ -4,7 +4,7 @@ public record CreateCompartimentRequestDto(
     int Number,
     double Nominal,
     double Operative,
-    double? Stock,
+    int IdProduct,
     double Height,
     int IdTank);
 

--- a/Poliedro.Eds.Application/Compartiment/Commands/UpdateServer/UpdateCompartimentCommand.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/UpdateServer/UpdateCompartimentCommand.cs
@@ -9,6 +9,6 @@ int IdCompartment,
 int Number,
 double Nominal,
 double Operative,
-double Stock,
+int IdProduct,
 double Height,
 int IdTank) : IRequest<Result<VoidResult, Error>>;

--- a/Poliedro.Eds.Application/Compartiment/Commands/UpdateServer/UpdateCompartimentCommandValidator.cs
+++ b/Poliedro.Eds.Application/Compartiment/Commands/UpdateServer/UpdateCompartimentCommandValidator.cs
@@ -20,11 +20,10 @@ namespace Poliedro.Eds.Application.Compartiment.Commands.UpdateCompartiment
             RuleFor(x => x.Nominal)
                 .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("NominalGreaterThanOrEqualTo").GetAwaiter().GetResult());
             RuleFor(x => x.Operative)
-                .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult())
-                .LessThanOrEqualTo(x => x.Stock).WithMessage(redisService.GetValueFromCacheAsync("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult());
+                .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("OperativeGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
-            RuleFor(x => x.Stock)
-                .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("StockGreaterThanOrEqualTo").GetAwaiter().GetResult());
+            RuleFor(x => x.IdProduct)
+                .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("IdProductGreaterThanOrEqualTo").GetAwaiter().GetResult());
 
             RuleFor(x => x.Height)
                 .GreaterThanOrEqualTo(0).WithMessage(redisService.GetValueFromCacheAsync("HeightGreaterThanOrEqualTo").GetAwaiter().GetResult());

--- a/Poliedro.Eds.Application/Compartiment/Dtos/CompartimentDto.cs
+++ b/Poliedro.Eds.Application/Compartiment/Dtos/CompartimentDto.cs
@@ -2,11 +2,11 @@
 namespace Poliedro.Eds.Application.Compartiment.Dtos;
 
 public record CompartimentDto(
-    int IdCompartment,
+    int IdCompartiment,
     int Number,
     double Nominal,
     double Operative,
-    double Stock,
+    int IdProduct,
     double Height,
     int IdTank
     );

--- a/Poliedro.Eds.Application/ShoppingProduct/Commands/CreateShoppingProduct/CreateShoppingProductCommandValidator.cs
+++ b/Poliedro.Eds.Application/ShoppingProduct/Commands/CreateShoppingProduct/CreateShoppingProductCommandValidator.cs
@@ -16,27 +16,27 @@ public class CreateShoppingProductCommandValidator : AbstractValidator<CreateSho
     {
         _compartimentService = compartimentService;
 
-        RuleFor(x => x)
-            .MustAsync(async (dto, cancellation) =>
-            {
-                var compartimentResult = await _compartimentService.GetByIdAsync(dto.IdCompartment);
-                if (!compartimentResult.IsSuccess || compartimentResult.Value == null)
-                    return false;
+        //RuleFor(x => x)
+        //    .MustAsync(async (dto, cancellation) =>
+        //    {
+        //        var compartimentResult = await _compartimentService.GetByIdAsync(dto.IdCompartment);
+        //        if (!compartimentResult.IsSuccess || compartimentResult.Value == null)
+        //            return false;
 
-                var compartiment = compartimentResult.Value;
-                return dto.Quantity + compartiment.Stock < compartiment.Operative;
-            })
-            .WithMessage((dto, context) =>
-            {
-                var compartimentResult = _compartimentService.GetByIdAsync(dto.IdCompartment).Result;
-                if (compartimentResult.IsSuccess && compartimentResult.Value != null)
-                {
-                    var compartiment = compartimentResult.Value;
-                    var suma = dto.Quantity + compartiment.Stock;
-                    return $"Hay {compartiment.Stock} gls en el Tanque, esta compra de {dto.Quantity} gls supera la capacidad operativa del Tanque ({compartiment.Operative} gls.)";
-                }
-                return "La suma de la compra más el stock actual supera la capacidad operativa del compartimento.";
-            });
+        //        var compartiment = compartimentResult.Value;
+        //        return dto.Quantity + compartiment.Stock < compartiment.Operative;
+        //    })
+        //    .WithMessage((dto, context) =>
+        //    {
+        //        var compartimentResult = _compartimentService.GetByIdAsync(dto.IdCompartment).Result;
+        //        if (compartimentResult.IsSuccess && compartimentResult.Value != null)
+        //        {
+        //            var compartiment = compartimentResult.Value;
+        //            var suma = dto.Quantity + compartiment.Stock;
+        //            return $"Hay {compartiment.Stock} gls en el Tanque, esta compra de {dto.Quantity} gls supera la capacidad operativa del Tanque ({compartiment.Operative} gls.)";
+        //        }
+        //        return "La suma de la compra más el stock actual supera la capacidad operativa del compartimento.";
+        //    });
 
         //RuleFor(x => x)
         //    .MustAsync(async (dto, cancellation) =>

--- a/Poliedro.Eds.Domain/Compartiment/Entities/CompartimentEntity.cs
+++ b/Poliedro.Eds.Domain/Compartiment/Entities/CompartimentEntity.cs
@@ -4,11 +4,11 @@ namespace Poliedro.Eds.Domain.Compartiment.Entities;
 
 public class CompartimentEntity : AuditableEntity
 {
-    public int IdCompartment { get; set; }
+    public int IdCompartiment { get; set; }
     public int Number { get; set; }
     public double Nominal { get; set; }
     public double Operative { get; set; }
-    public double? Stock { get; set; }
+    public int IdProduct { get; set; }
     public double Height { get; set; }
     public int IdTank { get; set; }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Compartiment/DomainService/Impl/CompartimentGetByIdService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Compartiment/DomainService/Impl/CompartimentGetByIdService.cs
@@ -27,7 +27,7 @@ public class CompartimentGetByIdService(ITenantDbContextFactory dbContextFactory
         using var context = dbContextFactory.CreateDbContext();
 
         var data = await context.Compartiment
-            .FirstAsync(c => c.IdCompartment == id);
+            .FirstAsync(c => c.IdCompartiment == id);
 
         await redisService.SetCacheAsync(cacheKey, data, TimeSpan.FromMinutes(1440));
 
@@ -39,6 +39,6 @@ public class CompartimentGetByIdService(ITenantDbContextFactory dbContextFactory
         using var context = dbContextFactory.CreateDbContext();
         return await context.Compartiment
             .AsNoTracking()
-            .AnyAsync(c => c.IdCompartment == id);
+            .AnyAsync(c => c.IdCompartiment == id);
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Compartiment/DomainService/Impl/CompartimentUpdateService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Compartiment/DomainService/Impl/CompartimentUpdateService.cs
@@ -14,8 +14,8 @@ public class CompartimentUpdateService(ITenantDbContextFactory dbContextFactory,
 {
     public async Task<Result<VoidResult, Error>> UpdateAsync(CompartimentEntity compartimentEntity)
     {
-        if (!await EntityExists(compartimentEntity.IdCompartment))
-            return CompartimentErrorBuilder.CompartimentNotFoundException(compartimentEntity.IdCompartment);
+        if (!await EntityExists(compartimentEntity.IdCompartiment))
+            return CompartimentErrorBuilder.CompartimentNotFoundException(compartimentEntity.IdCompartiment);
 
         using var context = dbContextFactory.CreateDbContext();
         context.Compartiment.Update(compartimentEntity);
@@ -32,6 +32,6 @@ public class CompartimentUpdateService(ITenantDbContextFactory dbContextFactory,
         using var context = dbContextFactory.CreateDbContext();
         return await context.Compartiment
             .AsNoTracking()
-            .AnyAsync(c => c.IdCompartment == id);
+            .AnyAsync(c => c.IdCompartiment == id);
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/CompartimentConfiguration.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/CompartimentConfiguration.cs
@@ -9,12 +9,12 @@ public class CompartimentConfiguration
     public CompartimentConfiguration(EntityTypeBuilder<CompartimentEntity> builder)
     {
         builder.ToTable("compartiment");
-        builder.HasKey(x => x.IdCompartment);
-        builder.Property(x => x.IdCompartment).HasColumnName("id_compartiment");
+        builder.HasKey(x => x.IdCompartiment);
+        builder.Property(x => x.IdCompartiment).HasColumnName("id_compartiment");
         builder.Property(x => x.Number).HasColumnName("number");
         builder.Property(x => x.Nominal).HasColumnName("nominal");
         builder.Property(x => x.Operative).HasColumnName("operative");
-        builder.Property(x => x.Stock).HasColumnName("stock");
+        builder.Property(x => x.IdProduct).HasColumnName("id_product");
         builder.Property(x => x.Height).HasColumnName("height");
         builder.Property(x => x.IdTank).HasColumnName("id_tank");
     }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Refactor the Compartiment domain model and validators to replace the old Stock property with a new IdProduct field, fix naming mismatches for compartment identifiers, disable an outdated capacity check in shopping product creation, and improve error handling in the Compartiment API endpoints.

New Features:
- Add IdProduct field to Compartiment DTOs, entities, and commands
- Enforce IdProduct > 0 validation in create and update command validators

Bug Fixes:
- Correct property name from IdCompartment to IdCompartiment across entity, DTO, EF configuration, and services
- Fix entity existence checks and domain service lookups to use IdCompartiment
- Handle failure cases in the Create Compartiment API by returning BadRequest

Enhancements:
- Remove legacy Stock property and its Operative <= Stock validation from update commands
- Comment out the compartment capacity validation in CreateShoppingProductCommandValidator
- Update CreateCompartimentCommandHandler to return the full result instead of only the value