### PR TITLE
fix: Stock,PurchasePrice,SellPrice null Ok

### DIFF
--- a/Poliedro.Eds.Application/Product/Commands/CreateProduct/CreateProductRequestDto.cs
+++ b/Poliedro.Eds.Application/Product/Commands/CreateProduct/CreateProductRequestDto.cs
@@ -3,6 +3,6 @@ namespace Poliedro.Eds.Application.Product.Commands.CreateProduct;
 public record CreateProductRequestDto(
     string Name,
     int IdProductType,
-    Double SellPrice,
-    double PurchasePrice,
-    double Stock);
+    double? SellPrice,
+    double? PurchasePrice,
+    double? Stock);

--- a/Poliedro.Eds.Application/Product/Commands/UpdateProduct/UpdateProductCommand.cs
+++ b/Poliedro.Eds.Application/Product/Commands/UpdateProduct/UpdateProductCommand.cs
@@ -6,5 +6,5 @@ using Poliedro.Eds.Domain.Common.Results.Errors;
 
 namespace Poliedro.Eds.Application.Product.Commands.UpdateProduct;
 
-public record UpdateProductCommand(int IdProduct, string Name, int IdProductType, double SellPrice, double PurchasePrice,
-    double Stock) : IRequest<Result<VoidResult, Error>>;
+public record UpdateProductCommand(int IdProduct, string Name, int IdProductType, double? SellPrice, double? PurchasePrice,
+    double? Stock) : IRequest<Result<VoidResult, Error>>;

--- a/Poliedro.Eds.Application/Product/Dtos/ProductDto.cs
+++ b/Poliedro.Eds.Application/Product/Dtos/ProductDto.cs
@@ -3,6 +3,6 @@ namespace Poliedro.Eds.Application.Product.Dtos;
 public record ProductDto(int IdProduct,
     string Name,
     int IdProductType,
-    double SellPrice,
-    double PurchasePrice,
-    double Stock);
+    double? SellPrice,
+    double? PurchasePrice,
+    double? Stock);

--- a/Poliedro.Eds.Domain/Hose/Dtos/HoseDto.cs
+++ b/Poliedro.Eds.Domain/Hose/Dtos/HoseDto.cs
@@ -34,9 +34,9 @@ public record CleanProductDto(
     int IdProduct,
     string Name,
     int IdProductType,
-    double PurchasePrice,
-    double SellPrice,
-    double Stock,
+    double? PurchasePrice,
+    double? SellPrice,
+    double? Stock,
     DateTime date
 );
 

--- a/Poliedro.Eds.Domain/Product/Entities/ProductEntity.cs
+++ b/Poliedro.Eds.Domain/Product/Entities/ProductEntity.cs
@@ -10,9 +10,9 @@ public class ProductEntity : AuditableEntity
     public int IdProduct { get; set; } = default!;
     public string Name { get; set; } = default!;
     public int IdProductType { get; set; }
-    public double PurchasePrice { get; set; }
-    public double SellPrice { get; set; }
-    public double Stock { get; set; }
+    public double? PurchasePrice { get; set; }
+    public double? SellPrice { get; set; }
+    public double? Stock { get; set; }
     public DateTime Date { get; set; }
 
     // Navigation property

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/ProductConfiguration.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/ProductConfiguration.cs
@@ -13,9 +13,20 @@ public class ProductConfiguration
         builder.Property(x => x.IdProduct).HasColumnName("id_product");
         builder.Property(x => x.Name).HasColumnName("name");
         builder.Property(x => x.IdProductType).HasColumnName("id_product_type");
-        builder.Property(x => x.PurchasePrice).HasColumnName("purchase_price");
-        builder.Property(x => x.SellPrice).HasColumnName("sell_price");
-        builder.Property(x => x.Stock).HasColumnName("stock");
+        
+        // Configure nullable properties
+        builder.Property(x => x.PurchasePrice)
+            .HasColumnName("purchase_price")
+            .IsRequired(false);
+            
+        builder.Property(x => x.SellPrice)
+            .HasColumnName("sell_price")
+            .IsRequired(false);
+            
+        builder.Property(x => x.Stock)
+            .HasColumnName("stock")
+            .IsRequired(false);
+            
         builder.Property(x => x.Date).HasColumnName("date");
 
         // Configure relationship with ProductType


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Allow PurchasePrice, SellPrice, and Stock to be nullable across the application and database mapping

Enhancements:
- Change PurchasePrice, SellPrice, and Stock properties to nullable doubles in domain entities, DTOs, and command/request records
- Mark the purchase_price, sell_price, and stock columns as optional in the EF Core Product entity configuration