### PR TITLE
fix(strongbox): reestrucure logic

### DIFF
--- a/Poliedro.Eds.Application/Court/Commands/CreateCourt/Handler/CreateCourtCommandHandle.cs
+++ b/Poliedro.Eds.Application/Court/Commands/CreateCourt/Handler/CreateCourtCommandHandle.cs
@@ -159,7 +159,6 @@ namespace Poliedro.Eds.Application.Court.Commands.CreateCourt.Handler
                 await mediator.Send(
                     new StrongBoxCreateCommand(new StrongBoxDtoCreateRequest
                     {
-                        DateTime = DateTime.Now,
                         IdCorte = courtEntity.IdCourt,
                         Type = "CORTE",
                         Ammount = money,

--- a/Poliedro.Eds.Application/StrongBox/Commands/StrongBoxCreateCommandHandler.cs
+++ b/Poliedro.Eds.Application/StrongBox/Commands/StrongBoxCreateCommandHandler.cs
@@ -4,41 +4,25 @@ using FluentValidation;
 using FluentValidation.Results;
 using MediatR;
 using Poliedro.Eds.Application.StrongBox.Validation;
+using Poliedro.Eds.Domain.StrongBox.Entities;
 using Poliedro.Eds.Domain.StrongBox.Exceptions;
 using Poliedro.Eds.Domain.StrongBox.Services;
 
-namespace Poliedro.Eds.Application.StrongBox.Commands
+namespace Poliedro.Eds.Application.StrongBox.Commands;
+
+public class StrongBoxCreateCommandHandler(
+    IStrongBoxService strongBoxService,
+    IMapper mapper,
+    StrongBoxCreateValidator validator) : IRequestHandler<StrongBoxCreateCommand, Unit>
 {
-    public class StrongBoxCreateCommandHandler(
-        IStrongBoxService strongBoxService,
-        IMapper mapper,
-        StrongBoxCreateValidator validator) : IRequestHandler<StrongBoxCreateCommand, Unit>
+    async Task<Unit> IRequestHandler<StrongBoxCreateCommand, Unit>.Handle(StrongBoxCreateCommand request, CancellationToken cancellationToken)
     {
-        async Task<Unit> IRequestHandler<StrongBoxCreateCommand, Unit>.Handle(StrongBoxCreateCommand request, CancellationToken cancellationToken)
-        {
-            await validator.ValidateAndThrowAsync(request.Request, cancellationToken);
+        await validator.ValidateAndThrowAsync(request.Request, cancellationToken);
 
-            try
-            {
-
-                var created = await strongBoxService.CreateAsync(
-                    DateTime.UtcNow,
-                    request.Request.IdCorte,
-                    request.Request.Type,
-                    request.Request.Ammount,
-                    request.Request.Note,
-                    cancellationToken);
-            }
-            catch (StrongBoxDomainException ex)
-            {
-                var failures = new List<ValidationFailure>
-                {
-                    new ValidationFailure("Ammount", ex.Message)
-                };
-                throw new ValidationException(failures);
-            }
-
-            return Unit.Value;
-        }
+        await strongBoxService.CreateAsync(
+        mapper.Map<StrongBoxEntity>(request.Request),
+        cancellationToken);
+        
+        return Unit.Value;
     }
 }

--- a/Poliedro.Eds.Application/StrongBox/Dtos/StrongBoxDtoCreateRequest.cs
+++ b/Poliedro.Eds.Application/StrongBox/Dtos/StrongBoxDtoCreateRequest.cs
@@ -8,8 +8,6 @@ namespace Poliedro.Eds.Application.StrongBox.Dtos;
 
 public class StrongBoxDtoCreateRequest
 {
-   // public DateTime DateTime { get; set; }
-
     public long? IdCorte { get; set; }
 
     public string Type { get; set; }

--- a/Poliedro.Eds.Application/StrongBox/Querys/StrongBoxGetTotalBalance/StrongBoxGetTotalBalanceHandler.cs
+++ b/Poliedro.Eds.Application/StrongBox/Querys/StrongBoxGetTotalBalance/StrongBoxGetTotalBalanceHandler.cs
@@ -17,7 +17,7 @@ public class StrongBoxGetTotalBalanceHandler(IStrongBoxRepositoryGetLast _repo) 
         return new StrongBoxTotalBalanceDto
         {
             Id = last?.Id,
-            DateTime = last?.DateTime,
+            DateTime = last?.CreatedAt,
             Saldo = last?.Saldo ?? 0m
         };
     }

--- a/Poliedro.Eds.Domain/StrongBox/Entities/StrongBoxEntity.cs
+++ b/Poliedro.Eds.Domain/StrongBox/Entities/StrongBoxEntity.cs
@@ -8,7 +8,6 @@ namespace Poliedro.Eds.Domain.StrongBox.Entities;
 public class StrongBoxEntity : AuditableEntity
 {
     public long Id { get; private set; }
-    public DateTime DateTime { get; private set; }
     public long? IdCorte { get; private set; }
     public string Type { get; private set; } = null!;
     public decimal Ammount { get; private set; }
@@ -18,7 +17,6 @@ public class StrongBoxEntity : AuditableEntity
     private StrongBoxEntity() { }
 
     public StrongBoxEntity(
-        DateTime dateTime,
         long? idCorte,
         string type,
         decimal ammount,
@@ -41,7 +39,6 @@ public class StrongBoxEntity : AuditableEntity
             throw new ArgumentException("Ammount debe ser mayor a 0", nameof(ammount));
         }
 
-        DateTime = DateTime.UtcNow;
         IdCorte = idCorte;
         Type = type;
         Ammount = decimal.Round(ammount, 2);

--- a/Poliedro.Eds.Domain/StrongBox/Services/IStrongBoxService.cs
+++ b/Poliedro.Eds.Domain/StrongBox/Services/IStrongBoxService.cs
@@ -10,10 +10,6 @@ namespace Poliedro.Eds.Domain.StrongBox.Services;
 public interface IStrongBoxService
 {
     Task<StrongBoxEntity> CreateAsync(
-        DateTime dateTime,
-        long? idCorte,
-        string type,
-        decimal ammount,
-        string? note,
+        StrongBoxEntity strongBoxEntity,
         CancellationToken cancellationToken);
 }

--- a/Poliedro.Eds.Domain/StrongBox/Services/StrongBoxService.cs
+++ b/Poliedro.Eds.Domain/StrongBox/Services/StrongBoxService.cs
@@ -8,74 +8,58 @@ using Poliedro.Eds.Domain.StrongBox.Repositories;
 using Poliedro.Eds.Domain.StrongBox.ValueObjects;
 using Poliedro.Eds.Domain.StrongBox.Exceptions;
 
-namespace Poliedro.Eds.Domain.StrongBox.Services
+namespace Poliedro.Eds.Domain.StrongBox.Services;
+
+public class StrongBoxService(IStrongBoxRepositoryGetLast _repo,
+        IStrongBoxRepositoryCreate repoCreate,
+        IStrongBoxRepositorySaveChanges repoSaveChanges) : IStrongBoxService
 {
-    public class StrongBoxService : IStrongBoxService
+  
+    public async Task<StrongBoxEntity> CreateAsync(StrongBoxEntity strongBoxEntity, CancellationToken cancellationToken)
     {
-        private readonly IStrongBoxRepositoryGetLast _strongBoxRepositoryGetLast;
-        private readonly IStrongBoxRepositoryCreate _strongBoxRepositoryCreate;
-        private readonly IStrongBoxRepositorySaveChanges _strongBoxRepositorySaveChanges;
-        public StrongBoxService(IStrongBoxRepositoryGetLast repo,
-            IStrongBoxRepositoryCreate repoCreate,
-            IStrongBoxRepositorySaveChanges repoSaveChanges)
+        if (strongBoxEntity.Ammount <= 0)
+            throw new StrongBoxDomainException("El monto debe ser mayor a cero.");
+
+        if (string.IsNullOrWhiteSpace(strongBoxEntity.Type))
+            throw new StrongBoxDomainException("El tipo de movimiento es requerido.");
+
+         strongBoxEntity.Type.Trim().ToUpperInvariant();
+
+        if (strongBoxEntity.Type != StrongBoxType.CORTE && strongBoxEntity.Type != StrongBoxType.RETIRO)
+            throw new StrongBoxDomainException($"Tipo de movimiento no soportado: {strongBoxEntity.Type}");
+
+        var last = await _repo.GetLastAsync(cancellationToken);
+        var previousBalance = last?.Saldo ?? 0;
+
+        decimal newBalance = previousBalance;
+
+        switch (strongBoxEntity.Type)
         {
-            _strongBoxRepositoryGetLast = repo;
-            _strongBoxRepositoryCreate = repoCreate;
-            _strongBoxRepositorySaveChanges = repoSaveChanges;
+            case StrongBoxType.CORTE:
+                // Siempre suma el monto al saldo anterior
+                newBalance += strongBoxEntity.Ammount;
+                break;
+            case StrongBoxType.RETIRO:
+                // Si el retiro es igual al saldo, el saldo queda en cero
+                if (strongBoxEntity.Ammount == previousBalance)
+                {
+                    newBalance = 0;
+                }
+                else
+                {
+                    newBalance -= strongBoxEntity.Ammount;
+                    if (newBalance < 0)
+                        throw new StrongBoxDomainException("No se puede hacer el retiro, el saldo quedaría negativo.");
+                }
+                break;
         }
-        public async Task<StrongBoxEntity> CreateAsync(DateTime dateTime, long? idCorte, string type, decimal ammount, string? note, CancellationToken cancellationToken)
-        {
-            if (ammount <= 0)
-                throw new StrongBoxDomainException("El monto debe ser mayor a cero.");
 
-            if (string.IsNullOrWhiteSpace(type))
-                throw new StrongBoxDomainException("El tipo de movimiento es requerido.");
 
-            type = type.Trim().ToUpperInvariant();
 
-            if (type != StrongBoxType.CORTE && type != StrongBoxType.RETIRO)
-                throw new StrongBoxDomainException($"Tipo de movimiento no soportado: {type}");
+         await repoCreate.CreateAsync(strongBoxEntity, cancellationToken);
 
-            var last = await _strongBoxRepositoryGetLast.GetLastAsync(cancellationToken);
-            var previousBalance = last?.Saldo ?? 0;
+        return strongBoxEntity;
 
-            decimal newBalance = previousBalance;
 
-            switch (type)
-            {
-                case StrongBoxType.CORTE:
-                    // Siempre suma el monto al saldo anterior
-                    newBalance += ammount;
-                    break;
-                case StrongBoxType.RETIRO:
-                    // Si el retiro es igual al saldo, el saldo queda en cero
-                    if (ammount == previousBalance)
-                    {
-                        newBalance = 0;
-                    }
-                    else
-                    {
-                        newBalance -= ammount;
-                        if (newBalance < 0)
-                            throw new StrongBoxDomainException("No se puede hacer el retiro, el saldo quedaría negativo.");
-                    }
-                    break;
-            }
-
-            var entity = new StrongBoxEntity(
-                dateTime,
-                idCorte,
-                type,
-                ammount,
-                saldo: newBalance,
-                note
-            );
-
-            await _strongBoxRepositoryCreate.CreateAsync(entity, cancellationToken);
-            // Si se requiere guardar cambios explícitamente, descomentar:
-            // await _strongBoxRepositorySaveChanges.SaveChangesAsync(cancellationToken);
-
-            return entity;
-        }
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/StrongBoxConfiguration.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/StrongBoxConfiguration.cs
@@ -7,25 +7,20 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Poliedro.Eds.Domain.StrongBox.Entities;
 
-namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.EntityFramework.EntityConfigurations
+namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.EntityFramework.EntityConfigurations;
+
+public class StrongBoxConfiguration
 {
-    public class StrongBoxConfiguration
+    public StrongBoxConfiguration(EntityTypeBuilder<StrongBoxEntity> entity)
     {
-        public StrongBoxConfiguration(EntityTypeBuilder<StrongBoxEntity> entity)
-        {
-            entity.ToTable("strongbox");
-            entity.HasKey(x => x.Id);
+        entity.ToTable("strongbox");
+        entity.HasKey(x => x.Id);
 
-            entity.Property(x => x.Id).HasColumnName("id");
-            entity.Property(x => x.DateTime).HasColumnName("datetime");
-            entity.Property(x => x.IdCorte).HasColumnName("id_corte");
-            entity.Property(x => x.Type).HasColumnName("moviment").HasMaxLength(10);
-            entity.Property(x => x.Ammount).HasColumnName("ammount").HasPrecision(18, 2);
-            entity.Property(x => x.Saldo).HasColumnName("saldo").HasPrecision(18, 2);
-            entity.Property(x => x.Note).HasColumnName("note").HasMaxLength(500);
-
-
-            entity.HasIndex(x => x.DateTime);
-        }
+        entity.Property(x => x.Id).HasColumnName("id");
+        entity.Property(x => x.IdCorte).HasColumnName("id_corte");
+        entity.Property(x => x.Type).HasColumnName("moviment").HasMaxLength(10);
+        entity.Property(x => x.Ammount).HasColumnName("ammount").HasPrecision(18, 2);
+        entity.Property(x => x.Saldo).HasColumnName("saldo").HasPrecision(18, 2);
+        entity.Property(x => x.Note).HasColumnName("note").HasMaxLength(500);
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/StrongBox/DomainStrongBox/Impl/StrongBoxGetAllService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/StrongBox/DomainStrongBox/Impl/StrongBoxGetAllService.cs
@@ -8,30 +8,29 @@ using Poliedro.Eds.Domain.StrongBox.Repositories;
 using Poliedro.Eds.Infraestructure.Persistence.Mysql.Context;
 using Microsoft.EntityFrameworkCore;
 
-namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.StrongBox.DomainStrongBox
+namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.StrongBox.DomainStrongBox;
+
+public class StrongBoxGetAllService(ITenantDbContextFactory dbContextFactory) : IStrongBoxRepositoryGetAll
 {
-    public class StrongBoxGetAllService(ITenantDbContextFactory dbContextFactory) : IStrongBoxRepositoryGetAll
+    public async Task<List<StrongBoxEntity>> GetListAsync(int skip, int take, long? IdCorte, string? type, DateTime? from, DateTime? to, CancellationToken cancellationToken)
     {
-        public async Task<List<StrongBoxEntity>> GetListAsync(int skip, int take, long? IdCorte, string? type, DateTime? from, DateTime? to, CancellationToken cancellationToken)
+        using var db = dbContextFactory.CreateDbContext();
+        if (from.HasValue && to.HasValue && from > to)
         {
-            using var db = dbContextFactory.CreateDbContext();
-            if (from.HasValue && to.HasValue && from > to)
-            {
-                var tmp = from.Value; from = to; to = tmp;
-            }
-
-            var query = db.Set<StrongBoxEntity>().AsNoTracking();
-
-            if (IdCorte.HasValue) query = query.Where(x => x.IdCorte == IdCorte);
-            if (!string.IsNullOrWhiteSpace(type)) query = query.Where(x => x.Type == type);
-            if (from.HasValue) query = query.Where(x => x.DateTime >= from.Value);
-            if (to.HasValue) query = query.Where(x => x.DateTime <= to.Value);
-
-            return await query
-                .OrderByDescending(x => x.DateTime)
-                .Skip(skip)
-                .Take(take)
-                .ToListAsync(cancellationToken);
+            var tmp = from.Value; from = to; to = tmp;
         }
+
+        var query = db.Set<StrongBoxEntity>().AsNoTracking();
+
+        if (IdCorte.HasValue) query = query.Where(x => x.IdCorte == IdCorte);
+        if (!string.IsNullOrWhiteSpace(type)) query = query.Where(x => x.Type == type);
+        if (from.HasValue) query = query.Where(x => x.CreatedAt >= from.Value);
+        if (to.HasValue) query = query.Where(x => x.CreatedAt <= to.Value);
+
+        return await query
+            .OrderByDescending(x => x.CreatedAt)
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken);
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/StrongBox/DomainStrongBox/Impl/StrongBoxGetLastService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/StrongBox/DomainStrongBox/Impl/StrongBoxGetLastService.cs
@@ -17,7 +17,7 @@ namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.StrongBox.DomainStrongB
             using var db = dbContextFactory.CreateDbContext();
 
             return await db.Set<StrongBoxEntity>()
-                            .OrderByDescending(x => x.DateTime)
+                            .OrderByDescending(x => x.CreatedAt)
                             .ThenByDescending(x => x.Id)
                             .FirstOrDefaultAsync(cancellationToken);
         }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Refactor StrongBox domain and application layers to streamline entity creation and auditing, centralize validation and balance logic, and remove manual DateTime handling in favor of automatic CreatedAt assignment.

Enhancements:
- Convert StrongBoxService to primary constructor syntax and accept a domain entity parameter for CreateAsync
- Centralize amount/type validation and balance calculation within StrongBoxService, removing redundant repository save logic
- Update command handler to map DTOs to StrongBoxEntity, drop manual exception wrapping, and eliminate DateTime passing
- Remove explicit DateTime properties/parameters in DTOs, services, and handlers, replacing them with the AuditableEntity's CreatedAt
- Align repository queries and ordering to use CreatedAt instead of DateTime and enforce file-scoped namespaces
- Simplify EF Core entity configuration for StrongBoxEntity by cleaning up namespace declarations and property mappings