### PR TITLE
fix(strongbox): reestrucure logic

### DIFF
--- a/Poliedro.Eds.Application/Court/Commands/CreateCourt/Handler/CreateCourtCommandHandle.cs
+++ b/Poliedro.Eds.Application/Court/Commands/CreateCourt/Handler/CreateCourtCommandHandle.cs
@@ -153,20 +153,20 @@ namespace Poliedro.Eds.Application.Court.Commands.CreateCourt.Handler
                 });
             }
 
-            var money = GetCashOnly(request);
-            if (money > 0)
-            {
-                await mediator.Send(
-                    new StrongBoxCreateCommand(new StrongBoxDtoCreateRequest
-                    {
-                        IdCorte = courtEntity.IdCourt,
-                        Type = "CORTE",
-                        Ammount = money,
-                        Note = $"Corte #{courtEntity.IdCourt} generado automaticamente",
-                    }),
-                    cancellationToken
-                );
-            }
+            //var money = GetCashOnly(request);
+            //if (money > 0)
+            //{
+            //    await mediator.Send(
+            //        new StrongBoxCreateCommand(new StrongBoxDtoCreateRequest
+            //        {
+            //            IdCorte = courtEntity.IdCourt,
+            //            Type = "CORTE",
+            //            Ammount = money,
+            //            Note = $"Corte #{courtEntity.IdCourt} generado automaticamente",
+            //        }),
+            //        cancellationToken
+            //    );
+            //}
 
             return result.Value!;
         }
@@ -205,14 +205,20 @@ namespace Poliedro.Eds.Application.Court.Commands.CreateCourt.Handler
             return command.CourtTypeOfCollections.Sum(d => d.Amount);
         }
 
-        private decimal GetCashOnly(CreateCourtCommand command)
+        private double GetCashOnly(CreateCourtCommand command)
         {
-            if (command.CourtTypeOfCollections is null) return 0m;
-
-            var bar = command.CourtTypeOfCollections
+            if (command.CourtTypeOfCollections is null) return 0;
+            double Expenditures = 0;
+            var efectivo = command.CourtTypeOfCollections
                 .Where(t => string.Equals(t.TypeOfCollectionName, "EFECTIVO", StringComparison.OrdinalIgnoreCase))
-                .Sum(t => (decimal)t.Amount);
-            return bar;
+                .Sum(t => (double)t.Amount);
+            if (command.CourtExpenditures?.Count() > 0)
+            {
+                Expenditures = command.CourtExpenditures
+                                .Sum(t => (double)t.Amount);
+            }
+           
+            return efectivo - Expenditures;
         }
     }
 }

--- a/Poliedro.Eds.Application/StrongBox/AutoMappers/StrongBoxProfile.cs
+++ b/Poliedro.Eds.Application/StrongBox/AutoMappers/StrongBoxProfile.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using AutoMapper;
+using Poliedro.Eds.Application.StrongBox.Commands;
 using Poliedro.Eds.Application.StrongBox.Dtos;
 using Poliedro.Eds.Domain.StrongBox.Entities;
 
@@ -15,5 +16,6 @@ public class StrongBoxProfile : Profile
     {
         CreateMap<Poliedro.Eds.Domain.StrongBox.Entities.StrongBoxEntity, Poliedro.Eds.Application.StrongBox.Dtos.StrongBoxDto>().ReverseMap();
         CreateMap<StrongBoxEntity, StrongBoxTotalBalanceDto>().ReverseMap();
+        CreateMap<StrongBoxEntity, StrongBoxCreateCommand>().ReverseMap();
     }
 }

--- a/Poliedro.Eds.Application/StrongBox/Dtos/StrongBoxDtoCreateRequest.cs
+++ b/Poliedro.Eds.Application/StrongBox/Dtos/StrongBoxDtoCreateRequest.cs
@@ -12,7 +12,7 @@ public class StrongBoxDtoCreateRequest
 
     public string Type { get; set; }
 
-    public decimal Ammount { get; set; }
+    public double Ammount { get; set; }
 
     public string? Note { get; set; }
 }

--- a/Poliedro.Eds.Application/StrongBox/Validation/StrongBoxCreateValidator.cs
+++ b/Poliedro.Eds.Application/StrongBox/Validation/StrongBoxCreateValidator.cs
@@ -27,17 +27,17 @@ public class StrongBoxCreateValidator : AbstractValidator<StrongBoxDtoCreateRequ
             .NotEmpty().WithMessage("El campo Monto es obligatorio.")
             .GreaterThan(0).WithMessage("El campo Monto debe ser mayor que 0.");
 
-        RuleFor(x => x)
-            .MustAsync(async (req, CancellationToken) =>
-            {
-                if (req?.Type?.Trim().ToUpperInvariant() == StrongBoxType.RETIRO)
-                {
-                    var last = await repoGetLast.GetLastAsync(CancellationToken);
-                    var balance = last?.Saldo ?? 0m;
-                    return req.Ammount <= balance;
-                }
-                return true;
+        //RuleFor(x => x)
+        //    .MustAsync(async (req, CancellationToken) =>
+        //    {
+        //        if (req?.Type?.Trim().ToUpperInvariant() == StrongBoxType.RETIRO)
+        //        {
+        //            var last = await repoGetLast.GetLastAsync(CancellationToken);
+        //            var balance = last?.Saldo ?? 0m;
+        //            return req.Ammount <= balance;
+        //        }
+        //        return true;
 
-            }).WithMessage("No se puede hacer el retiro el saldo no puede estar en negativo!!!");
+        //    }).WithMessage("No se puede hacer el retiro el saldo no puede estar en negativo!!!");
     }
 }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Restructure the strongbox integration and cash calculation in the court creation workflow

Enhancements:
- Disable automatic strongbox entry creation for court commands
- Compute net cash by subtracting expenditures and switch amounts from decimal to double
- Add AutoMapper mapping for StrongBoxCreateCommand

Chores:
- Comment out the strongbox withdrawal balance validation rule