### PR TITLE
fix:(cache) cache breaks on all services

### DIFF
--- a/Poliedro.Eds.Api/Program.cs
+++ b/Poliedro.Eds.Api/Program.cs
@@ -6,6 +6,7 @@ using AWS.Logger;
 using DotNetEnv;
 using FluentValidation;
 using HealthChecks.UI.Client;
+using MediatR;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
@@ -18,6 +19,10 @@ using Poliedro.Eds.Api.Middlelware.NameIdentifier;
 using Poliedro.Eds.Api.Middlelware.Tenant;
 using Poliedro.Eds.Application;
 using Poliedro.Eds.Application.Business.Commands.UpdateBusiness;
+using Poliedro.Eds.Application.Common.Behaviors;
+using Poliedro.Eds.Application.Common.EventHandlers.Cache;
+using Poliedro.Eds.Application.Common.Services.Background;
+using Poliedro.Eds.Application.Common.Services.Cache;
 using Poliedro.Eds.Application.Court.Queris.GetCourtList;
 using Poliedro.Eds.Application.FileUploadS3.Command;
 using Poliedro.Eds.Application.Ports.Redis;
@@ -27,6 +32,7 @@ using Poliedro.Eds.Application.Translations.Dtos;
 using Poliedro.Eds.Application.Translations.Handle;
 using Poliedro.Eds.Domain.Business.DomaianServices.Create;
 using Poliedro.Eds.Domain.Business.Extensions;
+using Poliedro.Eds.Domain.Common.Events;
 using Poliedro.Eds.Domain.Court.DomainService;
 using Poliedro.Eds.Domain.FileUploadS3.Ports;
 using Poliedro.Eds.Domain.Inventory.DomainService;
@@ -72,6 +78,19 @@ builder.Services.AddScoped<IBusinessUpdateService, BusinessUpdateService>();
 //builder.Services.AddScoped<IBusinessQueryService, BusinessQueryService>();
 
 builder.Services.AddScoped<IValidator<UpdateBusinessCommand>, UpdateBusinessCommandValidator>();
+
+// Servicios de caché con tags y invalidación distribuida
+builder.Services.AddScoped<ICacheService, CacheService>();
+
+// Event handlers para invalidación de caché
+builder.Services.AddScoped<CacheInvalidationEventHandler>();
+builder.Services.AddScoped<EntityModifiedEventHandler>();
+
+// Servicio de background para suscripción a invalidación de caché
+builder.Services.AddHostedService<CacheInvalidationSubscriberService>();
+
+// Domain Event Dispatcher
+builder.Services.AddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
 
 // Configure OpenAI
 builder.Services.AddScoped(provider =>
@@ -190,10 +209,14 @@ builder.Services.AddSwaggerGen(options =>
 });
 
 
+// Configuración de MediatR con el nuevo behavior de invalidación de caché
 builder.Services.AddMediatR(cfg =>
 {
     cfg.RegisterServicesFromAssemblyContaining<GetTranslationsHandler>();
     cfg.RegisterServicesFromAssemblyContaining<GetCourtsListQueryHandler>();
+    
+    // Agregar el behavior de invalidación de caché usando el método genérico
+    cfg.AddOpenBehavior(typeof(CacheInvalidationBehavior<,>));
 });
 
 builder.Services.AddMemoryCache();

--- a/Poliedro.Eds.Application/Common/Behaviors/CacheInvalidationBehavior.cs
+++ b/Poliedro.Eds.Application/Common/Behaviors/CacheInvalidationBehavior.cs
@@ -1,0 +1,169 @@
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Poliedro.Eds.Domain.Common.Events;
+using Poliedro.Eds.Domain.Common.Events.Cache;
+using System.Reflection;
+
+namespace Poliedro.Eds.Application.Common.Behaviors;
+
+
+public class CacheInvalidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly IDomainEventDispatcher _domainEventDispatcher;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<CacheInvalidationBehavior<TRequest, TResponse>> _logger;
+
+    public CacheInvalidationBehavior(
+        IDomainEventDispatcher domainEventDispatcher,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<CacheInvalidationBehavior<TRequest, TResponse>> logger)
+    {
+        _domainEventDispatcher = domainEventDispatcher;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        var response = await next();
+
+        if (IsWriteCommand(request) && IsSuccessfulResponse(response))
+        {
+            var tenant = GetTenantFromContext();
+            if (string.IsNullOrEmpty(tenant))
+            {
+                _logger.LogWarning("⚠️ No se pudo obtener el tenant del contexto para invalidación de caché");
+                return response;
+            }
+
+            var cacheMetadata = GetCacheInvalidationMetadata(request);
+            if (cacheMetadata != null)
+            {
+                _logger.LogInformation("🗑️ Disparando invalidación de caché automática para comando '{CommandType}'",
+                    typeof(TRequest).Name);
+
+                var domainEvent = new CacheInvalidationDomainEvent(
+                    tenant,
+                    cacheMetadata.Operation,
+                    cacheMetadata.EntityType,
+                    cacheMetadata.EntityId,
+                    cacheMetadata.AdditionalTags);
+
+                await _domainEventDispatcher.DispatchAsync(domainEvent, cancellationToken);
+            }
+        }
+
+        return response;
+    }
+
+    private static bool IsWriteCommand(TRequest request)
+    {
+        var requestType = typeof(TRequest);
+        var typeName = requestType.Name.ToLowerInvariant();
+        
+        return typeName.Contains("create") || 
+               typeName.Contains("update") || 
+               typeName.Contains("delete") ||
+               typeName.Contains("command");
+    }
+
+    private static bool IsSuccessfulResponse(TResponse response)
+    {
+        if (response == null) return false;
+        
+        var responseType = typeof(TResponse);
+        
+        if (responseType.IsGenericType && responseType.Name.StartsWith("Result"))
+        {
+            var isSuccessProperty = responseType.GetProperty("IsSuccess");
+            if (isSuccessProperty != null)
+            {
+                return (bool)(isSuccessProperty.GetValue(response) ?? false);
+            }
+        }
+
+        return true;
+    }
+
+    private string? GetTenantFromContext()
+    {
+        return _httpContextAccessor.HttpContext?.Items["tenant"]?.ToString();
+    }
+
+    private static CacheInvalidationMetadata? GetCacheInvalidationMetadata(TRequest request)
+    {
+        var requestType = typeof(TRequest);
+        var typeName = requestType.Name.ToLowerInvariant();
+
+        string operation = ExtractOperation(typeName);
+        string entityType = ExtractEntityType(typeName);
+        
+        if (string.IsNullOrEmpty(operation) || string.IsNullOrEmpty(entityType))
+        {
+            return null;
+        }
+
+        object? entityId = ExtractEntityId(request);
+
+        return new CacheInvalidationMetadata
+        {
+            Operation = operation,
+            EntityType = entityType,
+            EntityId = entityId,
+            AdditionalTags = Array.Empty<string>()
+        };
+    }
+
+    private static string ExtractOperation(string commandName)
+    {
+        if (commandName.Contains("create")) return "create";
+        if (commandName.Contains("update")) return "update";
+        if (commandName.Contains("delete")) return "delete";
+        
+        return "modify"; 
+    }
+
+    private static string ExtractEntityType(string commandName)
+    {
+        var cleaned = commandName
+            .Replace("create", "")
+            .Replace("update", "")
+            .Replace("delete", "")
+            .Replace("command", "")
+            .Replace("request", "")
+            .Trim();
+
+        return cleaned;
+    }
+
+    private static object? ExtractEntityId(TRequest request)
+    {
+        var requestType = typeof(TRequest);
+        
+        var idProperties = requestType.GetProperties()
+            .Where(p => p.Name.ToLowerInvariant().Contains("id"))
+            .ToArray();
+
+        if (idProperties.Any())
+        {
+            var idProperty = idProperties.FirstOrDefault(p => 
+                p.Name.Equals("Id", StringComparison.OrdinalIgnoreCase) ||
+                p.Name.Equals("IdEntity", StringComparison.OrdinalIgnoreCase)) 
+                ?? idProperties.First();
+
+            return idProperty.GetValue(request);
+        }
+
+        return null;
+    }
+
+    private class CacheInvalidationMetadata
+    {
+        public string Operation { get; set; } = string.Empty;
+        public string EntityType { get; set; } = string.Empty;
+        public object? EntityId { get; set; }
+        public string[] AdditionalTags { get; set; } = Array.Empty<string>();
+    }
+}

--- a/Poliedro.Eds.Application/Common/EventHandlers/Cache/CacheInvalidationEventHandler.cs
+++ b/Poliedro.Eds.Application/Common/EventHandlers/Cache/CacheInvalidationEventHandler.cs
@@ -1,0 +1,46 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Domain.Common.Events;
+using Poliedro.Eds.Domain.Common.Events.Cache;
+
+namespace Poliedro.Eds.Application.Common.EventHandlers.Cache;
+
+/// <summary>
+/// Handler para eventos de invalidación de caché
+/// </summary>
+public class CacheInvalidationEventHandler : IDomainEventHandler<CacheInvalidationDomainEvent>
+{
+    private readonly IRedisService _redisService;
+    private readonly ILogger<CacheInvalidationEventHandler> _logger;
+
+    public CacheInvalidationEventHandler(
+        IRedisService redisService,
+        ILogger<CacheInvalidationEventHandler> logger)
+    {
+        _redisService = redisService;
+        _logger = logger;
+    }
+
+    public async Task HandleAsync(CacheInvalidationDomainEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("🗑️ Procesando invalidación de caché para tenant '{Tenant}', operación '{Operation}', entidad '{EntityType}'",
+                domainEvent.Tenant, domainEvent.Operation, domainEvent.EntityType);
+
+            await _redisService.InvalidateDistributedCacheAsync(
+                domainEvent.Tenant,
+                domainEvent.Operation,
+                domainEvent.EntityType,
+                domainEvent.EntityId);
+
+            _logger.LogInformation("✅ Invalidación de caché completada exitosamente");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "❌ Error procesando evento de invalidación de caché para tenant '{Tenant}', entidad '{EntityType}'",
+                domainEvent.Tenant, domainEvent.EntityType);
+        }
+    }
+}

--- a/Poliedro.Eds.Application/Common/EventHandlers/Cache/EntityModifiedEventHandler.cs
+++ b/Poliedro.Eds.Application/Common/EventHandlers/Cache/EntityModifiedEventHandler.cs
@@ -1,0 +1,84 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Domain.Common.Events;
+using Poliedro.Eds.Domain.Common.Events.Cache;
+
+namespace Poliedro.Eds.Application.Common.EventHandlers.Cache;
+
+
+public class EntityModifiedEventHandler : IDomainEventHandler<EntityModifiedDomainEvent>
+{
+    private readonly IRedisService _redisService;
+    private readonly ILogger<EntityModifiedEventHandler> _logger;
+    
+    private static readonly Dictionary<string, string[]> EntityCacheRelations = new()
+    {
+        ["court"] = new[] { "court", "business", "dispensers", "product", "inventory", "expenditures", "typeofcollection" },
+        ["business"] = new[] { "business", "eds", "island" },
+        ["product"] = new[] { "product", "inventory", "compartiment", "productcompartment" },
+        ["islander"] = new[] { "islander", "business" },
+        ["dispensers"] = new[] { "dispensers", "hose", "island" },
+        ["tank"] = new[] { "tank", "edstank", "compartiment" },
+        ["inventory"] = new[] { "inventory", "product", "shoppingproductinventory" },
+        ["expenditures"] = new[] { "expenditures" },
+        ["typeofcollection"] = new[] { "typeofcollection" },
+        ["compartiment"] = new[] { "compartiment", "tank", "product" },
+        ["hose"] = new[] { "hose", "dispensers", "hosehistory" },
+        ["island"] = new[] { "island", "dispensers", "business" },
+        ["shopping"] = new[] { "shopping", "shoppingproduct", "inventory", "product" }
+    };
+
+    public EntityModifiedEventHandler(
+        IRedisService redisService,
+        ILogger<EntityModifiedEventHandler> logger)
+    {
+        _redisService = redisService;
+        _logger = logger;
+    }
+
+    public async Task HandleAsync(EntityModifiedDomainEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("🔄 Procesando modificación de entidad '{EntityType}' con operación '{Operation}' para tenant '{Tenant}'",
+                domainEvent.EntityType, domainEvent.Operation, domainEvent.Tenant);
+
+            var relatedEntities = GetRelatedEntitiesForCache(domainEvent.EntityType);
+            
+            var tags = new List<string>();
+            
+            foreach (var entity in relatedEntities)
+            {
+                tags.Add(_redisService.GetCacheTag(domainEvent.Tenant, entity));
+                tags.Add(_redisService.GetCacheTag(domainEvent.Tenant, $"{entity}:list"));
+            }
+            
+            tags.Add(_redisService.GetCacheTag(domainEvent.Tenant, $"{domainEvent.EntityType}:{domainEvent.EntityId}"));
+
+            await _redisService.InvalidateCacheByTagsAsync(tags.ToArray());
+            
+            await _redisService.PublishCacheInvalidationAsync(domainEvent.Tenant, tags.ToArray());
+
+            _logger.LogInformation("✅ Invalidación de caché completada para {EntityCount} tipos de entidad relacionados",
+                relatedEntities.Length);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "❌ Error procesando evento de modificación de entidad '{EntityType}' para tenant '{Tenant}'",
+                domainEvent.EntityType, domainEvent.Tenant);
+        }
+    }
+
+    private static string[] GetRelatedEntitiesForCache(string entityType)
+    {
+        var normalizedType = entityType.ToLowerInvariant();
+        
+        if (EntityCacheRelations.TryGetValue(normalizedType, out var relatedEntities))
+        {
+            return relatedEntities;
+        }
+
+        return new[] { normalizedType };
+    }
+}

--- a/Poliedro.Eds.Application/Common/Helper/removekey/RedisHelper.cs
+++ b/Poliedro.Eds.Application/Common/Helper/removekey/RedisHelper.cs
@@ -1,4 +1,7 @@
+using Microsoft.AspNetCore.Http;
 using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Domain.Common.Events;
+using Poliedro.Eds.Domain.Common.Events.Cache;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 
@@ -6,6 +9,7 @@ namespace Poliedro.Eds.Application.Common.Helper.removekey;
 
 public static class RedisHelper
 {
+
     public static async Task RemoveCacheIfSuccessAsync<T>(
         Result<T, Error> result,
         IRedisService redisService,
@@ -13,6 +17,58 @@ public static class RedisHelper
     {
         if (result.IsSuccess && keys.Length > 0)
             await redisService.RemoveByPrefixAsync(keys);
+    }
+
+
+    public static async Task InvalidateDistributedCacheAsync<T>(
+        Result<T, Error> result,
+        IRedisService redisService,
+        IDomainEventDispatcher eventDispatcher,
+        IHttpContextAccessor httpContextAccessor,
+        string entityType,
+        string operation = "modify",
+        object? entityId = null)
+    {
+        if (!result.IsSuccess) return;
+
+        var tenant = httpContextAccessor.HttpContext?.Items["tenant"]?.ToString();
+        if (string.IsNullOrEmpty(tenant)) return;
+
+        await redisService.InvalidateDistributedCacheAsync(tenant, operation, entityType, entityId);
+        
+        var domainEvent = new EntityModifiedDomainEvent(
+            tenant, 
+            entityType, 
+            entityId ?? Guid.NewGuid(), 
+            MapOperationToEnum(operation),
+            result.Value);
+
+        await eventDispatcher.DispatchAsync(domainEvent);
+    }
+
+    public static async Task InvalidateCacheByTagsAsync<T>(
+        Result<T, Error> result,
+        IRedisService redisService,
+        IHttpContextAccessor httpContextAccessor,
+        params string[] entityTypes)
+    {
+        if (!result.IsSuccess || entityTypes.Length == 0) return;
+
+        var tenant = httpContextAccessor.HttpContext?.Items["tenant"]?.ToString();
+        if (string.IsNullOrEmpty(tenant)) return;
+
+        await redisService.InvalidateCacheByTagsAsync(tenant, entityTypes);
+    }
+
+    private static EntityOperation MapOperationToEnum(string operation)
+    {
+        return operation.ToLowerInvariant() switch
+        {
+            "create" => EntityOperation.Created,
+            "update" => EntityOperation.Updated,
+            "delete" => EntityOperation.Deleted,
+            _ => EntityOperation.Updated
+        };
     }
 }
 

--- a/Poliedro.Eds.Application/Common/Services/Background/CacheInvalidationSubscriberService.cs
+++ b/Poliedro.Eds.Application/Common/Services/Background/CacheInvalidationSubscriberService.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Poliedro.Eds.Application.Ports.Redis;
+
+namespace Poliedro.Eds.Application.Common.Services.Background;
+
+
+public class CacheInvalidationSubscriberService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<CacheInvalidationSubscriberService> _logger;
+
+    public CacheInvalidationSubscriberService(
+        IServiceProvider serviceProvider,
+        ILogger<CacheInvalidationSubscriberService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("🔔 Iniciando servicio de suscripción a invalidación de caché...");
+
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var redisService = scope.ServiceProvider.GetRequiredService<IRedisService>();
+
+            await redisService.SubscribeToCacheInvalidationAsync(OnCacheInvalidationReceived);
+
+            _logger.LogInformation("✅ Servicio de suscripción a invalidación de caché iniciado correctamente");
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("🛑 Servicio de suscripción a invalidación de caché detenido");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "❌ Error en servicio de suscripción a invalidación de caché");
+        }
+    }
+
+    private async Task OnCacheInvalidationReceived(string tenant, string[] tags)
+    {
+        try
+        {
+            _logger.LogInformation("📨 Recibida notificación de invalidación de caché para tenant '{Tenant}' con tags: {Tags}",
+                tenant, string.Join(", ", tags));
+
+            using var scope = _serviceProvider.CreateScope();
+            var redisService = scope.ServiceProvider.GetRequiredService<IRedisService>();
+
+            // Invalidar caché local basado en los tags recibidos
+            await redisService.InvalidateCacheByTagsAsync(tags);
+
+            _logger.LogInformation("✅ Caché invalidado exitosamente para tenant '{Tenant}'", tenant);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "❌ Error procesando notificación de invalidación de caché para tenant '{Tenant}'", tenant);
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("🛑 Deteniendo servicio de suscripción a invalidación de caché...");
+        await base.StopAsync(stoppingToken);
+    }
+}

--- a/Poliedro.Eds.Application/Common/Services/Cache/CacheService.cs
+++ b/Poliedro.Eds.Application/Common/Services/Cache/CacheService.cs
@@ -1,0 +1,89 @@
+using Microsoft.AspNetCore.Http;
+using Poliedro.Eds.Application.Ports.Redis;
+
+namespace Poliedro.Eds.Application.Common.Services.Cache;
+
+public interface ICacheService
+{
+    Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default);
+    Task<T> GetOrSetAsync<T>(string key, Func<Task<T>> getItem, TimeSpan expiration, string[] tags, CancellationToken cancellationToken = default);
+    Task SetAsync<T>(string key, T value, TimeSpan expiration, string[] tags, CancellationToken cancellationToken = default);
+    Task RemoveAsync(string key, CancellationToken cancellationToken = default);
+    Task RemoveByTagsAsync(string[] tags, CancellationToken cancellationToken = default);
+    string GetTenantScopedKey(string key);
+}
+
+public class CacheService : ICacheService
+{
+    private readonly IRedisService _redisService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    
+    public CacheService(IRedisService redisService, IHttpContextAccessor httpContextAccessor)
+    {
+        _redisService = redisService;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        var scopedKey = GetTenantScopedKey(key);
+        return await _redisService.GetCacheAsync<T>(scopedKey);
+    }
+
+    public async Task<T> GetOrSetAsync<T>(string key, Func<Task<T>> getItem, TimeSpan expiration, string[] tags, CancellationToken cancellationToken = default)
+    {
+        var scopedKey = GetTenantScopedKey(key);
+        var cachedValue = await _redisService.GetCacheAsync<T>(scopedKey);
+        
+        if (cachedValue != null)
+        {
+            return cachedValue;
+        }
+
+        var value = await getItem();
+        await SetAsync(key, value, expiration, tags, cancellationToken);
+        
+        return value;
+    }
+
+    public async Task SetAsync<T>(string key, T value, TimeSpan expiration, string[] tags, CancellationToken cancellationToken = default)
+    {
+        var scopedKey = GetTenantScopedKey(key);
+        var scopedTags = GetTenantScopedTags(tags);
+        
+        await _redisService.SetCacheWithTagsAsync(scopedKey, value, expiration, scopedTags);
+    }
+
+    public async Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var scopedKey = GetTenantScopedKey(key);
+        await _redisService.RemoveCacheAsync(scopedKey);
+    }
+
+    public async Task RemoveByTagsAsync(string[] tags, CancellationToken cancellationToken = default)
+    {
+        var tenant = GetCurrentTenant();
+        if (string.IsNullOrEmpty(tenant)) return;
+        
+        await _redisService.InvalidateCacheByTagsAsync(tenant, tags);
+    }
+
+    public string GetTenantScopedKey(string key)
+    {
+        var tenant = GetCurrentTenant();
+        return string.IsNullOrEmpty(tenant) ? key : _redisService.GetTenantScopedKey(tenant, key);
+    }
+
+    private string[] GetTenantScopedTags(string[] tags)
+    {
+        var tenant = GetCurrentTenant();
+        if (string.IsNullOrEmpty(tenant)) return tags;
+        
+        return tags.Select(tag => _redisService.GetCacheTag(tenant, tag)).ToArray();
+    }
+
+    private string? GetCurrentTenant()
+    {
+        return _httpContextAccessor.HttpContext?.Items["tenant"]?.ToString();
+    }
+}

--- a/Poliedro.Eds.Application/Islander/Commands/CreateIslander/CreateIslanderCommandHandler.cs
+++ b/Poliedro.Eds.Application/Islander/Commands/CreateIslander/CreateIslanderCommandHandler.cs
@@ -4,9 +4,11 @@ using System.Text.Json;
 using AutoMapper;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Poliedro.Eds.Application.Common.Constants;
 using Poliedro.Eds.Application.Common.Helper.removekey;
 using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Domain.Common.Events;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Islander.DomainIslander;
@@ -20,6 +22,8 @@ namespace Poliedro.Eds.Application.Islander.Commands.CreateIslander
         IMapper mapper,
         IValidator<CreateIslanderRequestDto> validator,
         IRedisService redisService,
+        IDomainEventDispatcher domainEventDispatcher,
+        IHttpContextAccessor httpContextAccessor,
         IConnection rabbitConnection) : IRequestHandler<CreateIslanderCommand, Result<VoidResult, Error>>
     {
         public async Task<Result<VoidResult, Error>> Handle(CreateIslanderCommand request, CancellationToken cancellationToken)
@@ -40,7 +44,16 @@ namespace Poliedro.Eds.Application.Islander.Commands.CreateIslander
             islanderEntity.Password = BCrypt.Net.BCrypt.HashPassword(islanderEntity.Password);
 
             var result = await islanderDomainIslander.CreateAsync(islanderEntity);
-            await RedisHelper.RemoveCacheIfSuccessAsync(result, redisService, KeyRedisConstants.ISLANDER);
+            
+            // Usar el nuevo sistema de invalidación distribuida
+            await RedisHelper.InvalidateDistributedCacheAsync(
+                result, 
+                redisService, 
+                domainEventDispatcher, 
+                httpContextAccessor,
+                "islander",
+                "create",
+                islanderEntity.IdIslander);
 
             if (!result.IsSuccess)
                 return result.Error!;

--- a/Poliedro.Eds.Application/Poliedro.Eds.Application.csproj
+++ b/Poliedro.Eds.Application/Poliedro.Eds.Application.csproj
@@ -31,7 +31,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Common\Behaviors\" />
     <Folder Include="Inventory\AutoMappers\" />
     <Folder Include="Inventory\Commands\" />
     <Folder Include="Inventory\Dtos\" />

--- a/Poliedro.Eds.Application/Ports/Redis/IRedisService.cs
+++ b/Poliedro.Eds.Application/Ports/Redis/IRedisService.cs
@@ -4,17 +4,26 @@ namespace Poliedro.Eds.Application.Ports.Redis;
 
 public interface IRedisService
 {
+    // Métodos existentes
     Task SetCacheAsync<T>(string key, T value, TimeSpan expiration);
-
     Task<T?> GetCacheAsync<T>(string key);
-
     Task<bool> RemoveCacheAsync(string key);
-
     Task RemoveByPrefixAsync(string prefix);
-
     Task RemoveByPrefixAsync(IEnumerable<string> prefixes);
-
     Task<List<string>> GetKeysByPatternAsync(string pattern);
-
     Task<string?> GetValueFromCacheAsync(string key);
+
+    // Nuevos métodos para cache con tags y pub/sub
+    Task SetCacheWithTagsAsync<T>(string key, T value, TimeSpan expiration, params string[] tags);
+    Task InvalidateCacheByTagsAsync(params string[] tags);
+    Task InvalidateCacheByTagsAsync(string tenant, params string[] tags);
+    Task PublishCacheInvalidationAsync(string tenant, string[] tags);
+    Task SubscribeToCacheInvalidationAsync(Func<string, string[], Task> onMessage);
+    
+    // Método para invalidación distribuida entre servicios
+    Task InvalidateDistributedCacheAsync(string tenant, string operation, string entityType, object? entityId = null);
+    
+    // Helper para obtener keys con tenant scope
+    string GetTenantScopedKey(string tenant, string key);
+    string GetCacheTag(string tenant, string entityType);
 }

--- a/Poliedro.Eds.Application/Tank/Queries/GellAllTank/GetAllTankQueryHandler.cs
+++ b/Poliedro.Eds.Application/Tank/Queries/GellAllTank/GetAllTankQueryHandler.cs
@@ -1,7 +1,7 @@
 using AutoMapper;
 using MediatR;
 using Microsoft.AspNetCore.Http;
-using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Application.Common.Services.Cache;
 using Poliedro.Eds.Application.Tank.Dtos;
 using Poliedro.Eds.Domain.Tank.DomainTank;
 using Poliedro.Eds.Domain.Tank.Entities;
@@ -11,26 +11,31 @@ namespace Poliedro.Eds.Application.Tank.Queries.GellAllTank;
 public class GetAllTankQueryHandler
 (
     ITankGetAllTank TankGetAllService,
-    IRedisService redisService,
+    ICacheService cacheService,
     IHttpContextAccessor httpContextAccessor,
     IMapper mapper)
     : IRequestHandler<GellAllTankQuery, IEnumerable<TankDto>>
 {
     public async Task<IEnumerable<TankDto>> Handle(GellAllTankQuery request, CancellationToken cancellationToken)
     {
-        var tenant = httpContextAccessor.HttpContext.Items["tenant"]?.ToString();
-        var cacheKey = $"tank:{request.PaginationParams.PageNumber}:{request.PaginationParams.PageSize}:{tenant}";
-        var cachedData = await redisService.GetCacheAsync<IEnumerable<TankEntity>>(cacheKey);
-        if (cachedData is not null)
-        {
-            return mapper.Map<IEnumerable<TankDto>>(cachedData);
-        }
+        var tenant = httpContextAccessor.HttpContext?.Items["tenant"]?.ToString() ?? "default";
+        var cacheKey = $"tank:list:{request.PaginationParams.PageNumber}:{request.PaginationParams.PageSize}";
+        
 
-        var data = await TankGetAllService.GetAllAsync(request.PaginationParams);
+        var cacheTags = new[] { "tank", "edstank", "compartiment" };
+        
+        var data = await cacheService.GetOrSetAsync(
+            cacheKey,
+            async () =>
+            {
+                var entities = await TankGetAllService.GetAllAsync(request.PaginationParams);
+                return mapper.Map<IEnumerable<TankDto>>(entities);
+            },
+            TimeSpan.FromMinutes(1440), 
+            cacheTags,
+            cancellationToken);
 
-        await redisService.SetCacheAsync(cacheKey, data, TimeSpan.FromMinutes(1440));
-
-        return mapper.Map<IEnumerable<TankDto>>(data);
+        return data;
     }
 }
 

--- a/Poliedro.Eds.Domain/Common/Events/Cache/CacheInvalidationDomainEvent.cs
+++ b/Poliedro.Eds.Domain/Common/Events/Cache/CacheInvalidationDomainEvent.cs
@@ -1,0 +1,31 @@
+using Poliedro.Eds.Domain.Common.Events;
+
+namespace Poliedro.Eds.Domain.Common.Events.Cache;
+
+/// <summary>
+/// Evento de dominio para invalidación de caché
+/// </summary>
+public class CacheInvalidationDomainEvent : IDomainEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+    public DateTime OccurredOn { get; } = DateTime.UtcNow;
+    public string Tenant { get; }
+    public string Operation { get; }
+    public string EntityType { get; }
+    public object? EntityId { get; }
+    public string[] AdditionalTags { get; }
+
+    public CacheInvalidationDomainEvent(
+        string tenant,
+        string operation,
+        string entityType,
+        object? entityId = null,
+        params string[] additionalTags)
+    {
+        Tenant = tenant;
+        Operation = operation;
+        EntityType = entityType;
+        EntityId = entityId;
+        AdditionalTags = additionalTags ?? Array.Empty<string>();
+    }
+}

--- a/Poliedro.Eds.Domain/Common/Events/Cache/EntityModifiedDomainEvent.cs
+++ b/Poliedro.Eds.Domain/Common/Events/Cache/EntityModifiedDomainEvent.cs
@@ -1,0 +1,38 @@
+using Poliedro.Eds.Domain.Common.Events;
+
+namespace Poliedro.Eds.Domain.Common.Events.Cache;
+
+/// <summary>
+/// Evento de dominio específico para operaciones de escritura que requieren invalidación de caché
+/// </summary>
+public class EntityModifiedDomainEvent : IDomainEvent
+{
+    public Guid EventId { get; } = Guid.NewGuid();
+    public DateTime OccurredOn { get; } = DateTime.UtcNow;
+    public string Tenant { get; }
+    public string EntityType { get; }
+    public object EntityId { get; }
+    public EntityOperation Operation { get; }
+    public object? EntityData { get; }
+
+    public EntityModifiedDomainEvent(
+        string tenant,
+        string entityType,
+        object entityId,
+        EntityOperation operation,
+        object? entityData = null)
+    {
+        Tenant = tenant;
+        EntityType = entityType;
+        EntityId = entityId;
+        Operation = operation;
+        EntityData = entityData;
+    }
+}
+
+public enum EntityOperation
+{
+    Created,
+    Updated,
+    Deleted
+}

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Court/Repositories/CourtTransactionalService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Court/Repositories/CourtTransactionalService.cs
@@ -1,9 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Http;
 using Poliedro.Eds.Application.Common.Constants;
 using Poliedro.Eds.Application.Common.Helper.removekey;
 using Poliedro.Eds.Application.Court.Errors;
 using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Domain.Common.Events;
 using Poliedro.Eds.Domain.Common.Results;
 using Poliedro.Eds.Domain.Common.Results.Errors;
 using Poliedro.Eds.Domain.Court.DomainService;
@@ -16,7 +18,9 @@ namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Court.Repositories
         ITenantDbContextFactory dbContextFactory,
         IGetProductAndCompartiment getProductAndCompartiment,
         ILogger<CourtTransactionalService> logger,
-        IRedisService redisService) : ICourtTransactionalService
+        IRedisService redisService,
+        IDomainEventDispatcher domainEventDispatcher,
+        IHttpContextAccessor httpContextAccessor) : ICourtTransactionalService
     {
         public async Task<Result<CourtEntity, Error>> ExecuteCourtTransactionAsync(
             CourtEntity courtEntity,
@@ -66,21 +70,17 @@ namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Court.Repositories
                 await transaction.CommitAsync(cancellationToken);
                 logger.LogInformation("✅ TRANSACCIÓN CONFIRMADA EXITOSAMENTE");
 
-                // 4. Limpiar cache solo después de commit exitoso
                 var result = Result<CourtEntity, Error>.Success(courtEntity);
-                await RedisHelper.RemoveCacheIfSuccessAsync(result, redisService,
-                    KeyRedisConstants.BUSINESS,
-                    KeyRedisConstants.COMPARTIMENT,
-                    KeyRedisConstants.DISPENSERS,
-                    KeyRedisConstants.EDS,
-                    KeyRedisConstants.EXPENDITURES,
-                    KeyRedisConstants.HOSE,
-                    KeyRedisConstants.ISLANDER,
-                    KeyRedisConstants.PRODUCT,
-                    KeyRedisConstants.TRANSLATION,
-                    KeyRedisConstants.TYPE_OF_COLLECTION);
+                await RedisHelper.InvalidateDistributedCacheAsync(
+                    result, 
+                    redisService, 
+                    domainEventDispatcher, 
+                    httpContextAccessor,
+                    "court",
+                    "create",
+                    courtEntity.IdCourt);
 
-                logger.LogInformation("✅ Cache limpiado");
+                logger.LogInformation("✅ Cache invalidado usando sistema distribuido");
                 logger.LogInformation("==========================================");
 
                 return result;
@@ -154,21 +154,18 @@ namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Court.Repositories
                 await transaction.CommitAsync(cancellationToken);
                 logger.LogInformation("✅ TRANSACCIÓN COMPLETA CONFIRMADA EXITOSAMENTE");
 
-                // 5. Limpiar cache solo después de commit exitoso
+                // 5. Invalidar caché usando el nuevo sistema distribuido
                 var result = Result<CourtEntity, Error>.Success(courtEntity);
-                await RedisHelper.RemoveCacheIfSuccessAsync(result, redisService,
-                    KeyRedisConstants.BUSINESS,
-                    KeyRedisConstants.COMPARTIMENT,
-                    KeyRedisConstants.DISPENSERS,
-                    KeyRedisConstants.EDS,
-                    KeyRedisConstants.EXPENDITURES,
-                    KeyRedisConstants.HOSE,
-                    KeyRedisConstants.ISLANDER,
-                    KeyRedisConstants.PRODUCT,
-                    KeyRedisConstants.TRANSLATION,
-                    KeyRedisConstants.TYPE_OF_COLLECTION);
+                await RedisHelper.InvalidateDistributedCacheAsync(
+                    result, 
+                    redisService, 
+                    domainEventDispatcher, 
+                    httpContextAccessor,
+                    "court",
+                    "create",
+                    courtEntity.IdCourt);
 
-                logger.LogInformation("✅ Cache limpiado");
+                logger.LogInformation("✅ Cache invalidado usando sistema distribuido");
                 logger.LogInformation("===================================================");
 
                 return result;

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Redis/RedisCacheService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Redis/RedisCacheService.cs
@@ -10,9 +10,13 @@ namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Redis;
 public class RedisCacheService : IRedisService
 {
     private readonly ConnectionMultiplexer _redis;
-    private readonly StackExchange.Redis.IDatabase _db;
-
-    public ILogger<BusinessGetAllService> Logger { get; }
+    private readonly IDatabase _db;
+    private readonly ISubscriber _subscriber;
+    private readonly IServer _server;
+    private readonly ILogger<BusinessGetAllService> _logger;
+    
+    private const string CACHE_TAGS_PREFIX = "cache:tags:";
+    private const string CACHE_INVALIDATION_CHANNEL = "cache:invalidation";
 
     public RedisCacheService(
         IOptions<RedisConfig> config,
@@ -21,8 +25,12 @@ public class RedisCacheService : IRedisService
     {
         _redis = ConnectionMultiplexer.Connect(config.Value.ConnectionString);
         _db = _redis.GetDatabase();
-        Logger = logger;
+        _subscriber = _redis.GetSubscriber();
+        _server = _redis.GetServer(_redis.GetEndPoints()[0]);
+        _logger = logger;
     }
+
+    #region Métodos existentes
 
     public async Task SetCacheAsync<T>(string key, T value, TimeSpan expiration)
     {
@@ -33,15 +41,13 @@ public class RedisCacheService : IRedisService
         }
         catch (RedisException ex)
         {
-            Console.WriteLine($"[Redis Error] The key could not be set '{key}': {ex.Message}");
+            _logger.LogError(ex, "[Redis Error] The key could not be set '{Key}'", key);
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[General error] setting cache: {ex.Message}");
+            _logger.LogError(ex, "[General error] setting cache");
         }
     }
-
-
 
     public async Task<T?> GetCacheAsync<T>(string key)
     {
@@ -51,27 +57,24 @@ public class RedisCacheService : IRedisService
 
             if (json.IsNullOrEmpty)
             {
-                Logger.LogInformation("Cache Miss for key: {Key}", key);
+                _logger.LogInformation("Cache Miss for key: {Key}", key);
                 return default;
             }
 
             var deserialized = JsonSerializer.Deserialize<T>(json);
-
             return deserialized;
         }
         catch (RedisException ex)
         {
-            Console.WriteLine($"[Redis Error] Could not get key '{key}': {ex.Message}");
+            _logger.LogError(ex, "[Redis Error] Could not get key '{Key}'", key);
             return default;
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[General error] getting cache: {ex.Message}");
+            _logger.LogError(ex, "[General error] getting cache");
             return default;
         }
     }
-
-
 
     public async Task<bool> RemoveCacheAsync(string key)
     {
@@ -81,7 +84,7 @@ public class RedisCacheService : IRedisService
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[Error] removing cache key '{key}': {ex.Message}");
+            _logger.LogError(ex, "[Error] removing cache key '{Key}'", key);
             return false;
         }
     }
@@ -90,10 +93,9 @@ public class RedisCacheService : IRedisService
     {
         try
         {
-            var server = _redis.GetServer(_redis.GetEndPoints()[0]);
             var keysToDelete = new List<RedisKey>();
 
-            await foreach (var key in server.KeysAsync(pattern: $"{prefix}*"))
+            await foreach (var key in _server.KeysAsync(pattern: $"{prefix}*"))
             {
                 keysToDelete.Add(key);
             }
@@ -105,7 +107,7 @@ public class RedisCacheService : IRedisService
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[Error] removing cache keys by prefix '{prefix}': {ex.Message}");
+            _logger.LogError(ex, "[Error] removing cache keys by prefix '{Prefix}'", prefix);
         }
     }
 
@@ -119,10 +121,9 @@ public class RedisCacheService : IRedisService
     {
         try
         {
-            var server = _redis.GetServer(_redis.GetEndPoints().First());
             var keys = new List<string>();
 
-            await foreach (var key in server.KeysAsync(pattern: $"*{pattern}*"))
+            await foreach (var key in _server.KeysAsync(pattern: $"*{pattern}*"))
             {
                 keys.Add(key.ToString());
             }
@@ -131,7 +132,7 @@ public class RedisCacheService : IRedisService
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error getting keys by pattern");
+            _logger.LogError(ex, "Error getting keys by pattern");
             return new List<string>();
         }
     }
@@ -146,4 +147,190 @@ public class RedisCacheService : IRedisService
         }
         return null;
     }
+
+    #endregion
+
+    #region Nuevos métodos con tags y pub/sub
+
+    public async Task SetCacheWithTagsAsync<T>(string key, T value, TimeSpan expiration, params string[] tags)
+    {
+        try
+        {
+            // Guardar el valor principal
+            var json = JsonSerializer.Serialize(value);
+            await _db.StringSetAsync(key, json, expiration);
+
+            // Asociar el key con cada tag
+            foreach (var tag in tags)
+            {
+                var tagKey = $"{CACHE_TAGS_PREFIX}{tag}";
+                await _db.SetAddAsync(tagKey, key);
+                await _db.KeyExpireAsync(tagKey, expiration.Add(TimeSpan.FromMinutes(5))); // Expirar tags un poco después
+            }
+
+            _logger.LogDebug("Cache set with key '{Key}' and tags: {Tags}", key, string.Join(", ", tags));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Error] setting cache with tags for key '{Key}'", key);
+        }
+    }
+
+    public async Task InvalidateCacheByTagsAsync(params string[] tags)
+    {
+        try
+        {
+            var keysToDelete = new HashSet<RedisKey>();
+
+            foreach (var tag in tags)
+            {
+                var tagKey = $"{CACHE_TAGS_PREFIX}{tag}";
+                var taggedKeys = await _db.SetMembersAsync(tagKey);
+                
+                foreach (var key in taggedKeys)
+                {
+                    keysToDelete.Add(key.ToString()); // Convertir RedisValue a string y luego a RedisKey implícitamente
+                }
+                
+                // Eliminar el tag también
+                keysToDelete.Add(tagKey);
+            }
+
+            if (keysToDelete.Count > 0)
+            {
+                var deletedCount = await _db.KeyDeleteAsync(keysToDelete.ToArray());
+                _logger.LogInformation("Cache invalidated by tags {Tags}: {DeletedCount} keys deleted", 
+                    string.Join(", ", tags), deletedCount);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Error] invalidating cache by tags: {Tags}", string.Join(", ", tags));
+        }
+    }
+
+    public async Task InvalidateCacheByTagsAsync(string tenant, params string[] tags)
+    {
+        try
+        {
+            var tenantScopedTags = tags.Select(tag => GetCacheTag(tenant, tag)).ToArray();
+            await InvalidateCacheByTagsAsync(tenantScopedTags);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Error] invalidating cache by tenant '{Tenant}' and tags: {Tags}", 
+                tenant, string.Join(", ", tags));
+        }
+    }
+
+    public async Task PublishCacheInvalidationAsync(string tenant, string[] tags)
+    {
+        try
+        {
+            var message = JsonSerializer.Serialize(new
+            {
+                Tenant = tenant,
+                Tags = tags,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+
+            await _subscriber.PublishAsync(CACHE_INVALIDATION_CHANNEL, message);
+            _logger.LogInformation("Published cache invalidation for tenant '{Tenant}' with tags: {Tags}", 
+                tenant, string.Join(", ", tags));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Error] publishing cache invalidation message");
+        }
+    }
+
+    public async Task SubscribeToCacheInvalidationAsync(Func<string, string[], Task> onMessage)
+    {
+        try
+        {
+            await _subscriber.SubscribeAsync(CACHE_INVALIDATION_CHANNEL, async (channel, message) =>
+            {
+                try
+                {
+                    // Convertir explícitamente a string para evitar ambigüedad
+                    var messageString = message.ToString();
+                    using var document = JsonDocument.Parse(messageString);
+                    var root = document.RootElement;
+                    
+                    var tenant = root.GetProperty("Tenant").GetString() ?? string.Empty;
+                    var tags = root.GetProperty("Tags")
+                        .EnumerateArray()
+                        .Select(x => x.GetString())
+                        .Where(x => !string.IsNullOrEmpty(x))
+                        .ToArray()!;
+
+                    await onMessage(tenant, tags);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "[Error] processing cache invalidation message: {Message}", message);
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Error] subscribing to cache invalidation");
+        }
+    }
+
+    public async Task InvalidateDistributedCacheAsync(string tenant, string operation, string entityType, object? entityId = null)
+    {
+        try
+        {
+            var tags = new List<string>
+            {
+                GetCacheTag(tenant, entityType),
+                GetCacheTag(tenant, "all") // Tag global para invalidar todo
+            };
+
+            // Agregar tags específicos basados en la operación
+            switch (operation.ToLower())
+            {
+                case "create":
+                case "update":
+                case "delete":
+                    // Invalidar listas y entidades relacionadas
+                    tags.Add(GetCacheTag(tenant, $"{entityType}:list"));
+                    if (entityId != null)
+                    {
+                        tags.Add(GetCacheTag(tenant, $"{entityType}:{entityId}"));
+                    }
+                    break;
+            }
+
+            // Invalidar localmente primero
+            await InvalidateCacheByTagsAsync(tags.ToArray());
+            
+            // Luego notificar a otros servicios
+            await PublishCacheInvalidationAsync(tenant, tags.ToArray());
+
+            _logger.LogInformation("Distributed cache invalidation completed for tenant '{Tenant}', operation '{Operation}', entity '{EntityType}'",
+                tenant, operation, entityType);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Error] invalidating distributed cache");
+        }
+    }
+
+    #endregion
+
+    #region Helper methods
+
+    public string GetTenantScopedKey(string tenant, string key)
+    {
+        return $"{tenant}:{key}";
+    }
+
+    public string GetCacheTag(string tenant, string entityType)
+    {
+        return $"{tenant}:{entityType}";
+    }
+
+    #endregion
 }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Implement a resilient tag-based, tenant-scoped, distributed cache invalidation system across services by extending RedisCacheService with tagging, pub/sub, and tenant helpers; introduce CacheService and MediatR pipeline behavior to trigger invalidation events; register domain events, handlers, and a background subscriber; and update existing handlers to use the new caching infrastructure.

New Features:
- Extend RedisCacheService with methods for cache tagging, tenant-scoped keys, pub/sub invalidation, and distributed cache invalidation.
- Introduce CacheService wrapper with GetOrSetAsync and tag-based operations for simplified caching in application handlers.
- Add MediatR CacheInvalidationBehavior to automatically dispatch cache invalidation events for write commands.
- Define EntityModifiedDomainEvent and CacheInvalidationDomainEvent with corresponding event handlers and a background subscriber service.

Enhancements:
- Replace all Console.WriteLine calls in RedisCacheService with structured ILogger logging.
- Refactor RedisCacheService to reuse IServer and ISubscriber instances and centralize key/tag prefix constants.
- Update transactional and command/query handlers to use the new distributed invalidation instead of basic prefix removal.

Chores:
- Register ICacheService, domain event dispatcher, event handlers, background subscriber, and the MediatR invalidation behavior in the DI container.