### PR TITLE
feat: (phone):new field name

### DIFF
--- a/Poliedro.Eds.Application/Phone/AutoMappers/PhoneMapper.cs
+++ b/Poliedro.Eds.Application/Phone/AutoMappers/PhoneMapper.cs
@@ -14,5 +14,6 @@ public class PhoneMapper : Profile
         CreateMap<PhoneEntity, CreatePhoneCommand>().ReverseMap();
         CreateMap<PhoneEntity, CreatePhoneRequestDto>().ReverseMap();
         CreateMap<PhoneEntity, UpdatePhoneCommand>().ReverseMap();
+        CreateMap<PhoneEntity, PhoneCreateDto>().ReverseMap();
     }
 }

--- a/Poliedro.Eds.Application/Phone/Commands/CreatePhone/CreatePhoneCommandHandler.cs
+++ b/Poliedro.Eds.Application/Phone/Commands/CreatePhone/CreatePhoneCommandHandler.cs
@@ -29,8 +29,12 @@ public class CreatePhoneCommandHandler(
                     HttpStatusCode.BadRequest));
         }
 
-        var phoneEntities = request.Request.Numbers
-            .Select(number => new PhoneEntity { Number = NormalizePhoneNumber(number) })
+        var phoneEntities = request.Request.Phones
+            .Select(phone => new PhoneEntity 
+            { 
+                Number = NormalizePhoneNumber(phone.Number),
+                Name = phone.Name
+            })
             .ToList();
 
         foreach (var phoneEntity in phoneEntities)

--- a/Poliedro.Eds.Application/Phone/Commands/CreatePhone/CreatePhoneCommandValidator.cs
+++ b/Poliedro.Eds.Application/Phone/Commands/CreatePhone/CreatePhoneCommandValidator.cs
@@ -7,9 +7,17 @@ public class CreatePhoneCommandValidator : AbstractValidator<CreatePhoneRequestD
 {
     public CreatePhoneCommandValidator(IRedisService redisService)
     {
-        //RuleFor(x => x.Number)
-        //    .NotNull().WithMessage(redisService.GetValueFromCacheAsync("PhoneNumberNotNull").GetAwaiter().GetResult())
-        //    .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("PhoneNumberNotEmpty").GetAwaiter().GetResult())
-        //    .MaximumLength(13).WithMessage(redisService.GetValueFromCacheAsync("PhoneNumberMaxLength").GetAwaiter().GetResult());
+        RuleForEach(x => x.Phones).ChildRules(phone =>
+        {
+            phone.RuleFor(p => p.Number)
+                .NotNull().WithMessage("El número de teléfono es requerido")
+                .NotEmpty().WithMessage("El número de teléfono no puede estar vacío")
+                .MaximumLength(13).WithMessage("El número de teléfono no puede exceder 13 caracteres");
+
+            phone.RuleFor(p => p.Name)
+                .NotNull().WithMessage("El nombre es requerido")
+                .NotEmpty().WithMessage("El nombre no puede estar vacío")
+                .MaximumLength(100).WithMessage("El nombre no puede exceder 100 caracteres");
+        });
     }
 }

--- a/Poliedro.Eds.Application/Phone/Commands/CreatePhone/CreatePhoneRequestDto.cs
+++ b/Poliedro.Eds.Application/Phone/Commands/CreatePhone/CreatePhoneRequestDto.cs
@@ -1,3 +1,5 @@
 namespace Poliedro.Eds.Application.Phone.Commands.CreatePhone;
 
-public record CreatePhoneRequestDto(List<string> Numbers);
+public record CreatePhoneRequestDto(List<PhoneCreateDto> Phones);
+
+public record PhoneCreateDto(string Number, string Name);

--- a/Poliedro.Eds.Application/Phone/Commands/UpdatePhone/UpdatePhoneCommand.cs
+++ b/Poliedro.Eds.Application/Phone/Commands/UpdatePhone/UpdatePhoneCommand.cs
@@ -4,4 +4,4 @@ using Poliedro.Eds.Domain.Common.Results.Errors;
 
 namespace Poliedro.Eds.Application.Phone.Commands.UpdatePhone;
 
-public record UpdatePhoneCommand(int IdPhone, string Number) : IRequest<Result<VoidResult, Error>>;
+public record UpdatePhoneCommand(int IdPhone, string Number, string Name) : IRequest<Result<VoidResult, Error>>;

--- a/Poliedro.Eds.Application/Phone/Commands/UpdatePhone/UpdatePhoneCommandValidator.cs
+++ b/Poliedro.Eds.Application/Phone/Commands/UpdatePhone/UpdatePhoneCommandValidator.cs
@@ -7,13 +7,18 @@ public class UpdatePhoneCommandValidator : AbstractValidator<UpdatePhoneCommand>
 {
     public UpdatePhoneCommandValidator(IRedisService redisService)
     {
-        //RuleFor(x => x.IdPhone)
-        //    .NotNull()
-        //    .GreaterThan(0)
-        //    .WithMessage(redisService.GetValueFromCacheAsync("IdPhoneGreaterThan").GetAwaiter().GetResult());
+        RuleFor(x => x.IdPhone)
+            .NotNull().WithMessage("El ID del teléfono es requerido")
+            .GreaterThan(0).WithMessage("El ID del teléfono debe ser mayor que 0");
 
-        //RuleFor(x => x.Number)
-        //    .NotNull().WithMessage(redisService.GetValueFromCacheAsync("PhoneNumberNotNull").GetAwaiter().GetResult())
-        //    .NotEmpty().WithMessage(redisService.GetValueFromCacheAsync("PhoneNumberNotEmpty").GetAwaiter().GetResult());
+        RuleFor(x => x.Number)
+            .NotNull().WithMessage("El número de teléfono es requerido")
+            .NotEmpty().WithMessage("El número de teléfono no puede estar vacío")
+            .MaximumLength(13).WithMessage("El número de teléfono no puede exceder 13 caracteres");
+
+        RuleFor(x => x.Name)
+            .NotNull().WithMessage("El nombre es requerido")
+            .NotEmpty().WithMessage("El nombre no puede estar vacío")
+            .MaximumLength(100).WithMessage("El nombre no puede exceder 100 caracteres");
     }
 }

--- a/Poliedro.Eds.Application/Phone/Dtos/PhoneDto.cs
+++ b/Poliedro.Eds.Application/Phone/Dtos/PhoneDto.cs
@@ -4,4 +4,5 @@ public class PhoneDto
 {
     public int IdPhone { get; set; }
     public string Number { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
 }

--- a/Poliedro.Eds.Domain/Phone/Entities/PhoneEntity.cs
+++ b/Poliedro.Eds.Domain/Phone/Entities/PhoneEntity.cs
@@ -4,4 +4,5 @@ public class PhoneEntity
 {
     public int IdPhone { get; set; }
     public string Number { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/PhoneConfiguration.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/PhoneConfiguration.cs
@@ -12,5 +12,6 @@ public class PhoneConfiguration
         builder.HasKey(x => x.IdPhone);
         builder.Property(x => x.IdPhone).HasColumnName("id_phone");
         builder.Property(x => x.Number).HasColumnName("number").HasMaxLength(13).IsRequired();
+        builder.Property(x => x.Name).HasColumnName("name").HasMaxLength(100).IsRequired();
     }
 }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Add a new Name field to phone entities and integrate it throughout the create and update workflows, including DTOs, commands, handlers, mapping, persistence configuration, and validation.

New Features:
- Introduce Name property on PhoneEntity and PhoneDto
- Replace CreatePhoneRequestDto’s Numbers list with a Phones list of PhoneCreateDto including Name
- Extend UpdatePhoneCommand to include Name
- Include Name in create and update command handlers and AutoMapper mappings
- Configure the Name column in the EF Core PhoneConfiguration

Enhancements:
- Add validation rules for Number and Name fields (required, not empty, max length) in create and update validators
- Remove outdated commented-out validation rules