### PR TITLE
feat: (phone):validations to phone numbers

### DIFF
--- a/Poliedro.Eds.Application/Phone/Commands/CreatePhone/CreatePhoneCommandValidator.cs
+++ b/Poliedro.Eds.Application/Phone/Commands/CreatePhone/CreatePhoneCommandValidator.cs
@@ -1,23 +1,63 @@
 using FluentValidation;
 using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Domain.Phone.DomainServices.GetByNumber;
 
 namespace Poliedro.Eds.Application.Phone.Commands.CreatePhone;
 
 public class CreatePhoneCommandValidator : AbstractValidator<CreatePhoneRequestDto>
 {
-    public CreatePhoneCommandValidator(IRedisService redisService)
+    public CreatePhoneCommandValidator(IRedisService redisService, IPhoneGetByNumberService phoneGetByNumberService)
     {
         RuleForEach(x => x.Phones).ChildRules(phone =>
         {
             phone.RuleFor(p => p.Number)
                 .NotNull().WithMessage("El número de teléfono es requerido")
                 .NotEmpty().WithMessage("El número de teléfono no puede estar vacío")
-                .MaximumLength(13).WithMessage("El número de teléfono no puede exceder 13 caracteres");
+                .MaximumLength(13).WithMessage("El número de teléfono no puede exceder 13 caracteres")
+                .MustAsync(async (number, cancellation) =>
+                {
+                    if (string.IsNullOrWhiteSpace(number))
+                        return true; // Let other validators handle null/empty validation
+
+                    // Normalize the number first (same logic as in the handler)
+                    var normalizedNumber = NormalizePhoneNumber(number);
+                    return !await phoneGetByNumberService.ExistsAsync(normalizedNumber);
+                })
+                .WithMessage("El número de teléfono {PropertyValue} ya existe en la base de datos");
 
             phone.RuleFor(p => p.Name)
                 .NotNull().WithMessage("El nombre es requerido")
                 .NotEmpty().WithMessage("El nombre no puede estar vacío")
                 .MaximumLength(100).WithMessage("El nombre no puede exceder 100 caracteres");
         });
+
+        // Validate for duplicate numbers within the same request
+        RuleFor(x => x.Phones)
+            .Must(phones =>
+            {
+                if (phones == null || !phones.Any()) return true;
+
+                var normalizedNumbers = phones.Select(p => NormalizePhoneNumber(p.Number)).ToList();
+                return normalizedNumbers.Count == normalizedNumbers.Distinct().Count();
+            })
+            .WithMessage("No se pueden enviar números de teléfono duplicados en la misma solicitud");
+    }
+
+    private static string NormalizePhoneNumber(string number)
+    {
+        if (string.IsNullOrWhiteSpace(number)) return number;
+
+        var digits = new string(number.Where(char.IsDigit).ToArray());
+
+        if (digits.StartsWith("57") && digits.Length == 12)
+            return digits;
+
+        if (digits.StartsWith("0"))
+            digits = digits.Substring(1);
+
+        if (!digits.StartsWith("57"))
+            digits = "57" + digits;
+
+        return digits;
     }
 }

--- a/Poliedro.Eds.Application/Phone/Commands/UpdatePhone/UpdatePhoneCommandValidator.cs
+++ b/Poliedro.Eds.Application/Phone/Commands/UpdatePhone/UpdatePhoneCommandValidator.cs
@@ -1,11 +1,12 @@
 using FluentValidation;
 using Poliedro.Eds.Application.Ports.Redis;
+using Poliedro.Eds.Domain.Phone.DomainServices.GetByNumber;
 
 namespace Poliedro.Eds.Application.Phone.Commands.UpdatePhone;
 
 public class UpdatePhoneCommandValidator : AbstractValidator<UpdatePhoneCommand>
 {
-    public UpdatePhoneCommandValidator(IRedisService redisService)
+    public UpdatePhoneCommandValidator(IRedisService redisService, IPhoneGetByNumberService phoneGetByNumberService)
     {
         RuleFor(x => x.IdPhone)
             .NotNull().WithMessage("El ID del teléfono es requerido")
@@ -20,5 +21,46 @@ public class UpdatePhoneCommandValidator : AbstractValidator<UpdatePhoneCommand>
             .NotNull().WithMessage("El nombre es requerido")
             .NotEmpty().WithMessage("El nombre no puede estar vacío")
             .MaximumLength(100).WithMessage("El nombre no puede exceder 100 caracteres");
+
+        // Add unique number validation for updates
+        RuleFor(x => x)
+            .MustAsync(async (command, cancellation) =>
+            {
+                if (string.IsNullOrWhiteSpace(command.Number))
+                    return true; // Let other validators handle null/empty validation
+
+                // Normalize the number first
+                var normalizedNumber = NormalizePhoneNumber(command.Number);
+                var existingPhone = await phoneGetByNumberService.GetByNumberAsync(normalizedNumber);
+                
+                if (existingPhone.IsSuccess && existingPhone.Value != null)
+                {
+                    // Allow if the number belongs to the same phone being updated
+                    return existingPhone.Value.IdPhone == command.IdPhone;
+                }
+                
+                // Number doesn't exist, so it's unique
+                return true;
+            })
+            .WithMessage("El número de teléfono ya existe en la base de datos")
+            .WithName("Number");
+    }
+
+    private static string NormalizePhoneNumber(string number)
+    {
+        if (string.IsNullOrWhiteSpace(number)) return number;
+        
+        var digits = new string(number.Where(char.IsDigit).ToArray());
+
+        if (digits.StartsWith("57") && digits.Length == 12)
+            return digits;
+
+        if (digits.StartsWith("0"))
+            digits = digits.Substring(1);
+
+        if (!digits.StartsWith("57"))
+            digits = "57" + digits;
+
+        return digits;
     }
 }

--- a/Poliedro.Eds.Application/Poliedro.Eds.Application.csproj
+++ b/Poliedro.Eds.Application/Poliedro.Eds.Application.csproj
@@ -38,6 +38,7 @@
     <Folder Include="Inventory\Commands\" />
     <Folder Include="Inventory\Dtos\" />
     <Folder Include="Inventory\Queries\GetInventoryList\" />
+    <Folder Include="Phone\Validators\" />
   </ItemGroup>
 
 </Project>

--- a/Poliedro.Eds.Domain/Phone/DomainServices/GetByNumber/IPhoneGetByNumberService.cs
+++ b/Poliedro.Eds.Domain/Phone/DomainServices/GetByNumber/IPhoneGetByNumberService.cs
@@ -1,0 +1,11 @@
+using Poliedro.Eds.Domain.Common.Results;
+using Poliedro.Eds.Domain.Common.Results.Errors;
+using Poliedro.Eds.Domain.Phone.Entities;
+
+namespace Poliedro.Eds.Domain.Phone.DomainServices.GetByNumber;
+
+public interface IPhoneGetByNumberService
+{
+    Task<Result<PhoneEntity?, Error>> GetByNumberAsync(string number);
+    Task<bool> ExistsAsync(string number);
+}

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
@@ -29,6 +29,7 @@ using Poliedro.Eds.Domain.Islander.DomainIslander;
 using Poliedro.Eds.Domain.OpenAI.DomainOpenAI;
 using Poliedro.Eds.Domain.Phone.DomainServices.Create;
 using Poliedro.Eds.Domain.Phone.DomainServices.GetAll;
+using Poliedro.Eds.Domain.Phone.DomainServices.GetByNumber;
 using Poliedro.Eds.Domain.Phone.DomainServices.Update;
 using Poliedro.Eds.Domain.Ports;
 using Poliedro.Eds.Domain.Product.DomainProduct;
@@ -101,6 +102,7 @@ public static class DependencyInjectionService
         services.AddScoped<IPhoneCreateService, PhoneCreateService>();
         services.AddScoped<IPhoneGetAllService, PhoneGetAllService>();
         services.AddScoped<IPhoneUpdateService, PhoneUpdateService>();
+        services.AddScoped<IPhoneGetByNumberService, PhoneGetByNumberService>();
         services.AddScoped<ICapacityCreateService, CapacityCreateService>();
         services.AddScoped<ICapacityGetByIdService, CapacityGetByIdService>();
         services.AddScoped<ICapacityGetAllService, CapacityGetAllService>();
@@ -218,6 +220,7 @@ public static class DependencyInjectionService
         services.AddScoped<IStrongBoxService, StrongBoxService>();
         services.AddScoped<IStrongBoxRepositoryGetById, StrongBoxGetByIdService>();
         services.AddScoped<IStrongBoxRepositoryGetAll, StrongBoxGetAllService>();
+        
         return services;
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Phone/DomainService/Impl/PhoneGetByNumberService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Phone/DomainService/Impl/PhoneGetByNumberService.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Eds.Domain.Common.Results;
+using Poliedro.Eds.Domain.Common.Results.Errors;
+using Poliedro.Eds.Domain.Phone.DomainServices.GetByNumber;
+using Poliedro.Eds.Domain.Phone.Entities;
+using Poliedro.Eds.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Phone.DomainService.Impl;
+
+public class PhoneGetByNumberService(ITenantDbContextFactory dbContextFactory) : IPhoneGetByNumberService
+{
+    public async Task<Result<PhoneEntity?, Error>> GetByNumberAsync(string number)
+    {
+        using var context = dbContextFactory.CreateDbContext();
+        var phone = await context.Phone
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Number == number);
+        
+        return Result<PhoneEntity?, Error>.Success(phone);
+    }
+
+    public async Task<bool> ExistsAsync(string number)
+    {
+        using var context = dbContextFactory.CreateDbContext();
+        return await context.Phone
+            .AsNoTracking()
+            .AnyAsync(p => p.Number == number);
+    }
+}


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Enforce unique phone number constraints by integrating a new domain service for existence checks, applying normalization logic, and adding validation rules in both create and update workflows.

New Features:
- Add async uniqueness validation to CreatePhoneCommandValidator with database existence checks
- Prevent duplicate phone numbers in a single create request
- Add async uniqueness validation to UpdatePhoneCommandValidator, allowing existing record’s number
- Introduce a phone number normalization method shared by validators
- Define IPhoneGetByNumberService interface and implement it using EF Core

Enhancements:
- Register IPhoneGetByNumberService in the DI container