### PR TITLE
feat(strongbox): add id eds for strongbox

### DIFF
--- a/Poliedro.Eds.Api/Controllers/v1/StrongBox/StrongBoxController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/StrongBox/StrongBoxController.cs
@@ -6,6 +6,7 @@ using Poliedro.Eds.Application.Common.Features;
 using Poliedro.Eds.Application.StrongBox.Commands;
 using Poliedro.Eds.Application.StrongBox.Dtos;
 using Poliedro.Eds.Application.StrongBox.Querys.StrongBoxGetById;
+using Poliedro.Eds.Application.StrongBox.Querys.StrongBoxGetByEds;
 using Poliedro.Eds.Application.StrongBox.Querys.StrongBoxGetList;
 using Poliedro.Eds.Application.StrongBox.Querys.StrongBoxGetTotalBalance;
 using Poliedro.Eds.Domain.Common.Models;
@@ -44,6 +45,18 @@ namespace Poliedro.Eds.Api.Controllers.v1.StrongBox
         public async Task<IActionResult> GetById([FromRoute] long id)
         {
             var dto = await mediator.Send(new StrongBoxGetId(id));
+            return ApiResponse(dto, StatusCodes.Status200OK, StatusCodes.Status404NotFound);
+        }
+
+        [SwaggerOperation(Summary = "Get StrongBox records by EDS ID", Description = "Retrieves all StrongBox records associated with a specific EDS (Estación de Servicio) ID, ordered by creation date descending")]
+        [SwaggerResponse(StatusCodes.Status200OK, "Successful", typeof(List<StrongBoxDto>))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, "Not Found", typeof(ProblemDetails))]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized", typeof(ProblemDetails))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Bad Request", typeof(ProblemDetails))]
+        [HttpGet("eds/{idEds:int}")]
+        public async Task<IActionResult> GetByEds([FromRoute] int idEds)
+        {
+            var dto = await mediator.Send(new StrongBoxGetByEds(idEds));
             return ApiResponse(dto, StatusCodes.Status200OK, StatusCodes.Status404NotFound);
         }
 

--- a/Poliedro.Eds.Application/StrongBox/Querys/StrongBoxGetByEds/StrongBoxGetByEds.cs
+++ b/Poliedro.Eds.Application/StrongBox/Querys/StrongBoxGetByEds/StrongBoxGetByEds.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MediatR;
+using Poliedro.Eds.Application.StrongBox.Dtos;
+
+namespace Poliedro.Eds.Application.StrongBox.Querys.StrongBoxGetByEds;
+
+public record StrongBoxGetByEds(int IdEds) : IRequest<List<StrongBoxDto>>;

--- a/Poliedro.Eds.Application/StrongBox/Querys/StrongBoxGetByEds/StrongBoxGetByEdsHandler.cs
+++ b/Poliedro.Eds.Application/StrongBox/Querys/StrongBoxGetByEds/StrongBoxGetByEdsHandler.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoMapper;
+using MediatR;
+using Poliedro.Eds.Application.StrongBox.Dtos;
+using Poliedro.Eds.Domain.StrongBox.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace Poliedro.Eds.Application.StrongBox.Querys.StrongBoxGetByEds;
+
+public class StrongBoxGetByEdsHandler(
+    IStrongBoxRepositoryGetByEds repository, 
+    IMapper mapper,
+    ILogger<StrongBoxGetByEdsHandler> logger) 
+    : IRequestHandler<StrongBoxGetByEds, List<StrongBoxDto>>
+{
+    public async Task<List<StrongBoxDto>> Handle(StrongBoxGetByEds request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Getting StrongBox records for EDS ID: {IdEds}", request.IdEds);
+        
+        var entities = await repository.GetByEdsAsync(request.IdEds, cancellationToken);
+        var result = mapper.Map<List<StrongBoxDto>>(entities);
+        
+        logger.LogInformation("Found {Count} StrongBox records for EDS ID: {IdEds}", result.Count, request.IdEds);
+        
+        return result;
+    }
+}

--- a/Poliedro.Eds.Domain/StrongBox/Repositories/IStrongBoxRepositoryGetByEds.cs
+++ b/Poliedro.Eds.Domain/StrongBox/Repositories/IStrongBoxRepositoryGetByEds.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Poliedro.Eds.Domain.StrongBox.Entities;
+
+namespace Poliedro.Eds.Domain.StrongBox.Repositories;
+
+public interface IStrongBoxRepositoryGetByEds
+{
+    Task<List<StrongBoxEntity>> GetByEdsAsync(int idEds, CancellationToken cancellationToken);
+}

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
@@ -220,7 +220,8 @@ public static class DependencyInjectionService
         services.AddScoped<IStrongBoxService, StrongBoxService>();
         services.AddScoped<IStrongBoxRepositoryGetById, StrongBoxGetByIdService>();
         services.AddScoped<IStrongBoxRepositoryGetAll, StrongBoxGetAllService>();
-        
+        services.AddScoped<IStrongBoxRepositoryGetByEds, StrongBoxGetByEdsService>();
+
         return services;
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/StrongBox/DomainStrongBox/Impl/StrongBoxGetByEdsService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/StrongBox/DomainStrongBox/Impl/StrongBoxGetByEdsService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Eds.Domain.StrongBox.Entities;
+using Poliedro.Eds.Domain.StrongBox.Repositories;
+using Poliedro.Eds.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.StrongBox.DomainStrongBox;
+
+public class StrongBoxGetByEdsService(ITenantDbContextFactory dbContextFactory) : IStrongBoxRepositoryGetByEds
+{
+    public async Task<List<StrongBoxEntity>> GetByEdsAsync(int idEds, CancellationToken cancellationToken)
+    {
+        using var db = dbContextFactory.CreateDbContext();
+        return await db.Set<StrongBoxEntity>()
+            .AsNoTracking()
+            .Where(x => x.IdEds == idEds)
+            .OrderByDescending(x => x.CreatedAt)
+            .ToListAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Add support for retrieving StrongBox entries by EDS ID through a new API endpoint, MediatR query, repository interface and implementation, and DI registration

New Features:
- Add GET /eds/{idEds} endpoint to fetch StrongBox records by EDS ID
- Implement StrongBoxGetByEds MediatR query with handler and DTO mapping

Enhancements:
- Define IStrongBoxRepositoryGetByEds and its EF Core MySQL implementation to retrieve and order entities by creation date
- Register the new StrongBoxGetByEdsService in the dependency injection container