### PR TITLE
feat(keycloakservice): add user inslander

### DIFF
--- a/Poliedro.Eds.Api/Controllers/v1/Islander/IslanderController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Islander/IslanderController.cs
@@ -65,12 +65,7 @@ namespace Poliedro.Eds.Api.Controllers.v1.Islender
         public async Task<IResult> Create([FromBody] CreateIslanderCommand createIslanderCommand)
 
         {
-            var nameClaimToken = HttpContext.User.FindFirst("name")?.Value;
-
-            var command = new CreateIslanderCommand(createIslanderCommand.Request, nameClaimToken);
-
-            Console.WriteLine($"nombre del token: {nameClaimToken}");
-
+            var command = new CreateIslanderCommand(createIslanderCommand.Request, createIslanderCommand.NameClaimToken);
             var result = await mediator.Send(command);
             return result.Match(
                  onSuccess => TypedResults.Created()

--- a/Poliedro.Eds.Application/Islander/Commands/CreateIslander/CreateIslanderCommandHandler.cs
+++ b/Poliedro.Eds.Application/Islander/Commands/CreateIslander/CreateIslanderCommandHandler.cs
@@ -33,19 +33,16 @@ namespace Poliedro.Eds.Application.Islander.Commands.CreateIslander
                 return Result<VoidResult, Error>.Failure(
                     Error.CreateInstance("ValidationFailed", validationResult.Errors.ToString(), HttpStatusCode.BadRequest));
 
-            var islanderEntity = mapper.Map<IslanderEntity>(request.Request);
+            IslanderEntity islanderEntity = mapper.Map<IslanderEntity>(request.Request);
 
-            var nameClaimToken = request.NameClaimToken;
+            Console.WriteLine($"nombre del clain del token: {request.NameClaimToken}");
 
-            Console.WriteLine($"nombre del clain del token: {nameClaimToken}");
-
-            var originalPassword = islanderEntity.Password;
+            string originalPassword = islanderEntity.Password;
 
             islanderEntity.Password = BCrypt.Net.BCrypt.HashPassword(islanderEntity.Password);
 
             var result = await islanderDomainIslander.CreateAsync(islanderEntity);
             
-            // Usar el nuevo sistema de invalidación distribuida
             await RedisHelper.InvalidateDistributedCacheAsync(
                 result, 
                 redisService, 
@@ -71,7 +68,7 @@ namespace Poliedro.Eds.Application.Islander.Commands.CreateIslander
                 islanderEntity.FirstName,
                 islanderEntity.LastName,
                 Password = originalPassword,
-                
+                request.NameClaimToken,
             };
 
             var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(message));

--- a/Poliedro.Eds.Infraestructure.External.Keycloak/Services/KeycloakService.cs
+++ b/Poliedro.Eds.Infraestructure.External.Keycloak/Services/KeycloakService.cs
@@ -96,7 +96,7 @@ namespace Poliedro.Eds.Infraestructure.External.Keycloak.Services
                 }
 
 
-                var groupId = _configuration["Keycloak:registred-business-EDS"];
+                var groupId = _configuration["Keycloak:DefaultGroupId"];
 
                 var subgroupsUrl = $"{_configuration["Keycloak:KeycloakUri"]}/admin/realms/{realm}/groups/{groupId}/children";
                 var groupResponse = await _httpClient.GetAsync(subgroupsUrl);

--- a/WorkerKeycloackService/Worker.cs
+++ b/WorkerKeycloackService/Worker.cs
@@ -68,7 +68,7 @@ namespace WorkerKeycloackService
                     _logger.LogInformation("No hay mensajes en la cola.");
                 }
 
-                await Task.Delay(5000, stoppingToken);
+                await Task.Delay(30000, stoppingToken);
             }
 
             _logger.LogInformation("Worker detenido.");


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Refactor Islander creation to accept NameClaimToken from the request instead of extracting it in the controller, update Keycloak group configuration, and adjust worker polling interval.

Enhancements:
- Accept NameClaimToken via CreateIslanderCommand and remove direct HttpContext extraction in the controller
- Log the NameClaimToken in CreateIslanderCommandHandler and use explicit types for clarity
- Use Keycloak:DefaultGroupId configuration key instead of the previous group ID
- Increase Worker polling delay from 5 seconds to 30 seconds