### PR TITLE
Fix 280-duplicado-negocio

### DIFF
--- a/Poliedro.Eds.Api/Controllers/v1/Business/BusinessController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/Business/BusinessController.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -69,6 +70,7 @@ public class BusinessController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status201Created, "The operation was successful.")]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Incorrect request parameters.", typeof(ProblemDetails))]
     [SwaggerResponse(StatusCodes.Status401Unauthorized, "The request lacks valid authentication credentials.", typeof(ProblemDetails))]
+    [SwaggerResponse(StatusCodes.Status409Conflict, "The business name already exists. Please provide a different name.", typeof(ProblemDetails))]
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Error processing the request.", typeof(ProblemDetails))]
     [Authorize(Policy = "AdminOrIslander")]
     [HttpPost]
@@ -77,7 +79,19 @@ public class BusinessController(IMediator mediator) : ControllerBase
         [FromBody] CreateBusinessCommand createBusinessCommand)
     {
         var result = await mediator.Send(createBusinessCommand);
-        return result.Match(onSuccess => TypedResults.Created());
+
+        return result.Match(
+            onSuccess => TypedResults.Created(),
+            onFailure => result.Error.HttpStatusCode == HttpStatusCode.Conflict
+                ? TypedResults.Conflict(new
+                {
+                    status = 409,
+                    type = result.Error.Code,
+                    detail = result.Error.Description
+                })
+                : throw new Exception(result.Error.Description ?? "Unexpected error")
+        );
+
     }
 
     [SwaggerOperation(Summary = "Update an existing Business")]

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Business/DomainService/Impl/BusinessCreateService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Business/DomainService/Impl/BusinessCreateService.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
 using Poliedro.Eds.Application.Business.Errors;
 using Poliedro.Eds.Domain.Business.DomainBusiness;
 using Poliedro.Eds.Domain.Business.Entities;
@@ -12,10 +14,26 @@ public class BusinessCreateService(ITenantDbContextFactory dbContextFactory) : I
     public async Task<Result<VoidResult, Error>> CreateAsync(BusinessEntity BusinessEntity)
     {
         using var context = dbContextFactory.CreateDbContext();
+
+        var exists = await context.Business
+            .AnyAsync(b => b.Name.ToLower() == BusinessEntity.Name.ToLower());
+
+        if (exists)
+        {
+            return Result<VoidResult, Error>.Failure(
+                Error.CreateInstance(
+                    code: "BusinessAlreadyExists",
+                    description: "The business name already exists. Please enter a different name.",
+                    httpStatusCode: HttpStatusCode.Conflict
+                )
+            );
+        }
+
         await context.Business.AddAsync(BusinessEntity);
-        var result = await context.SaveChangesAsync() > 0;
-        if (!result)
+        var saved = await context.SaveChangesAsync() > 0;
+        if (!saved)
             return BusinessErrorBuilder.BusinessCreationException();
+
         return VoidResult.Instance;
     }
 }


### PR DESCRIPTION
# Solución duplicado al crear negocio

## Summary by Sourcery

Prevent creation of duplicate businesses by validating uniqueness in the service and return a 409 Conflict response for duplicate name errors in the API controller.

Bug Fixes:
- Check for existing business names in BusinessCreateService and return a BusinessAlreadyExists error if a duplicate is found

Enhancements:
- Modify BusinessController to match on conflict errors and return a TypedResults.Conflict response
- Rename SaveChanges result variable to 'saved' for clarity

Documentation:
- Add Swagger 409 Conflict response annotation to BusinessController Create endpoint