### PR TITLE
feat: BusinessDto: Add new data in bussiness service KeycloackId

### DIFF
--- a/Poliedro.Eds.Application/Business/Dtos/BusinessDto.cs
+++ b/Poliedro.Eds.Application/Business/Dtos/BusinessDto.cs
@@ -7,4 +7,5 @@ public class BusinessDto
     public string Name { get; set; }
 
     public string Context { get; set; }
+    public string KeycloakId { get; set; }
 }

--- a/Poliedro.Eds.Domain/Business/Entities/BusinessEntity.cs
+++ b/Poliedro.Eds.Domain/Business/Entities/BusinessEntity.cs
@@ -11,6 +11,7 @@ public class BusinessEntity : AggregateRoot
     public int IdBusiness { get; private set; }
     public string Name { get; private set; } = null!;
     public string Context { get; private set; } = null!;
+    public string? KeycloakId { get; private set; }
 
     private BusinessEntity(string name, string context)
     {
@@ -19,7 +20,9 @@ public class BusinessEntity : AggregateRoot
         Name = name;
         Context = context;
         CreatedAt = DateTime.UtcNow;
+        KeycloakId = null;
         AddDomainEvent(new BusinessCreated(name, context, IdBusiness));
+
     }
 
     public void Update(string name, string? context)

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/BusinessConfiguration.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/BusinessConfiguration.cs
@@ -13,5 +13,6 @@ public class BusinessConfiguration
         builder.Property(x => x.IdBusiness).HasColumnName("id_business");
         builder.Property(x => x.Name).HasColumnName("name");
         builder.Property(x => x.Context).HasColumnName("context");
+        builder.Property(x => x.KeycloakId).HasColumnName("keycloack");
     }
 }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [x] Code compiles correctly  
- [x] Tests have been added  
- [x] Documentation has been updated  
- [x] Team has been informed about the changes

## Summary by Sourcery

Add support for KeycloakId to business entities and DTOs

New Features:
- Add nullable KeycloakId property to BusinessEntity with default initialization
- Expose KeycloakId in BusinessDto
- Configure KeycloakId column mapping in EF persistence configuration