### PR TITLE
Ajustar zona horaria a Colombia en registros de base de datos

### DIFF
--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Audit/AuditableDbContext.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Audit/AuditableDbContext.cs
@@ -1,7 +1,7 @@
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Poliedro.Eds.Infraestructure.Persistence.Mysql.Utils;
 using Poliedro.Eds.Domain.Audit.Entities;
 using Poliedro.Eds.Infraestructure.Persistence.Mysql.Context;
 
@@ -25,7 +25,7 @@ namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Audit
                 if (entry.State == EntityState.Added)
                 {
                     entity.CreatedBy = currentUser;
-                    entity.CreatedAt = DateTime.UtcNow;
+                    entity.CreatedAt = DateTimeColombiaHelper.NowColombia(); // Cambiado a hora Colombia
                 }
 
                 if (entry.State == EntityState.Modified)
@@ -34,7 +34,7 @@ namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Audit
                     entry.Property(nameof(AuditableEntity.CreatedAt)).IsModified = false;
 
                     entity.UpdatedBy = currentUser;
-                    entity.UpdatedAt = DateTime.UtcNow;
+                    entity.UpdatedAt = DateTimeColombiaHelper.NowColombia(); // Cambiado a hora Colombia
                 }
             }
 

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/Utils/DateTimeColombiaHelper.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/Utils/DateTimeColombiaHelper.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.Utils
+{
+    public static class DateTimeColombiaHelper
+    {
+        private static readonly TimeZoneInfo ColombiaTimeZone = GetColombiaTimeZone();
+
+        private static TimeZoneInfo GetColombiaTimeZone()
+        {
+            var windowsId = "SA Pacific Standard Time";
+            var ianaId = "America/Bogota";
+
+            try
+            {
+                var id = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? windowsId : ianaId;
+                return TimeZoneInfo.FindSystemTimeZoneById(id);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                try
+                {
+                    return TimeZoneInfo.FindSystemTimeZoneById(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ianaId : windowsId);
+                }
+                catch
+                {
+                    return TimeZoneInfo.Utc;
+                }
+            }
+            catch (InvalidTimeZoneException)
+            {
+                return TimeZoneInfo.Utc;
+            }
+        }
+
+        public static DateTime ToColombiaTime(DateTime dateTime)
+        {
+            DateTime utc;
+            if (dateTime.Kind == DateTimeKind.Unspecified)
+                utc = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+            else if (dateTime.Kind == DateTimeKind.Local)
+                utc = dateTime.ToUniversalTime();
+            else
+                utc = dateTime; // already UTC
+
+            var colombia = TimeZoneInfo.ConvertTimeFromUtc(utc, ColombiaTimeZone);
+            return DateTime.SpecifyKind(colombia, DateTimeKind.Unspecified);
+        }
+
+        public static DateTime FromColombiaTime(DateTime colombiaDateTime)
+        {
+            var specified = DateTime.SpecifyKind(colombiaDateTime, DateTimeKind.Unspecified);
+            return TimeZoneInfo.ConvertTimeToUtc(specified, ColombiaTimeZone);
+        }
+
+        public static DateTime NowColombia()
+        {
+            return ToColombiaTime(DateTime.UtcNow);
+        }
+    }
+}

--- a/Poliedro.Eds.Utils/DateTimeColombiaHelper.cs
+++ b/Poliedro.Eds.Utils/DateTimeColombiaHelper.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Poliedro.Eds.Utils
+{
+    public static class DateTimeColombiaHelper
+    {
+        private static readonly TimeZoneInfo ColombiaTimeZone = GetColombiaTimeZone();
+
+        private static TimeZoneInfo GetColombiaTimeZone()
+        {
+            // Windows uses "SA Pacific Standard Time", Linux/macOS use "America/Bogota"
+            var windowsId = "SA Pacific Standard Time";
+            var ianaId = "America/Bogota";
+
+            try
+            {
+                var id = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? windowsId : ianaId;
+                return TimeZoneInfo.FindSystemTimeZoneById(id);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+                // Fallbacks: try the other id
+                try
+                {
+                    return TimeZoneInfo.FindSystemTimeZoneById(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ianaId : windowsId);
+                }
+                catch
+                {
+                    // As a last resort, return UTC to avoid crashes
+                    return TimeZoneInfo.Utc;
+                }
+            }
+            catch (InvalidTimeZoneException)
+            {
+                return TimeZoneInfo.Utc;
+            }
+        }
+
+        public static DateTime ToColombiaTime(DateTime dateTime)
+        {
+            DateTime utc;
+            if (dateTime.Kind == DateTimeKind.Unspecified)
+                utc = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+            else if (dateTime.Kind == DateTimeKind.Local)
+                utc = dateTime.ToUniversalTime();
+            else
+                utc = dateTime; // already UTC
+
+            var colombia = TimeZoneInfo.ConvertTimeFromUtc(utc, ColombiaTimeZone);
+            return DateTime.SpecifyKind(colombia, DateTimeKind.Unspecified);
+        }
+
+        public static DateTime FromColombiaTime(DateTime colombiaDateTime)
+        {
+            var specified = DateTime.SpecifyKind(colombiaDateTime, DateTimeKind.Unspecified);
+            return TimeZoneInfo.ConvertTimeToUtc(specified, ColombiaTimeZone);
+        }
+
+        public static DateTime NowColombia()
+        {
+            return ToColombiaTime(DateTime.UtcNow);
+        }
+    }
+}


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Adjust audit timestamp logic to use Colombia local time by adding a timezone helper and updating persistence layer calls to NowColombia().

New Features:
- Introduce DateTimeColombiaHelper to handle conversion to and from Colombia local time across different OS environments

Enhancements:
- Replace DateTime.UtcNow with DateTimeColombiaHelper.NowColombia() in AuditableDbContext to set CreatedAt and UpdatedAt timestamps