### PR TITLE
feat(validation): add update

### DIFF
--- a/Poliedro.Eds.Api/Controllers/v1/TransferValidation/TransferValidationController.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/TransferValidation/TransferValidationController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Poliedro.Eds.Application.Common.Features;
 using Poliedro.Eds.Application.TransferValidation.Commands.CreateTransferValidation;
+using Poliedro.Eds.Application.TransferValidation.Commands.UpdateTransferValidation;
 using Poliedro.Eds.Application.TransferValidation.Dtos;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -37,7 +38,6 @@ public class TransferValidationController(IMediator mediator) : ControllerBase
     [SwaggerResponse(StatusCodes.Status500InternalServerError, 
         "Error interno al procesar la solicitud.", 
         typeof(ProblemDetails))]
-
     [HttpPost]
     public async Task<IActionResult> Create(
         [FromBody] TransferValidationCreateRequestDto createRequest)
@@ -50,6 +50,58 @@ public class TransferValidationController(IMediator mediator) : ControllerBase
             return StatusCode(
                 StatusCodes.Status201Created,
                 ResponseApiService.Response(StatusCodes.Status201Created, result));
+        }
+        catch (ValidationException ex)
+        {
+            return BadRequest(
+                ResponseApiService.Response(StatusCodes.Status400BadRequest, ex.Errors));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(
+                StatusCodes.Status500InternalServerError,
+                ResponseApiService.Response(StatusCodes.Status500InternalServerError, ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// Actualiza una validación de transferencia bancaria existente
+    /// </summary>
+    /// <param name="id">ID de la validación de transferencia a actualizar</param>
+    /// <param name="updateRequest">Datos actualizados de la transferencia</param>
+    /// <returns>La validación de transferencia actualizada</returns>
+    [SwaggerOperation(
+        Summary = "Actualizar validación de transferencia",
+        Description = "Actualiza un registro existente de validación de transferencia bancaria en el sistema. " +
+                      "El ID se pasa como parámetro de consulta y los datos a actualizar en el cuerpo de la petición.")]
+    [SwaggerResponse(StatusCodes.Status200OK, 
+        "La validación de transferencia fue actualizada exitosamente.", 
+        typeof(TransferValidationDto))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, 
+        "Los parámetros de la solicitud son incorrectos o la validación falló.", 
+        typeof(ProblemDetails))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, 
+        "La solicitud carece de credenciales de autenticación válidas.", 
+        typeof(ProblemDetails))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, 
+        "No se encontró la validación de transferencia con el ID especificado.", 
+        typeof(ProblemDetails))]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, 
+        "Error interno al procesar la solicitud.", 
+        typeof(ProblemDetails))]
+    [HttpPut]
+    public async Task<IActionResult> Update(
+        [FromQuery] int id,
+        [FromBody] UpdateTransferValidationRequestDto updateRequest)
+    {
+        try
+        {
+            var command = new UpdateTransferValidationCommand(id, updateRequest);
+            var result = await mediator.Send(command);
+
+            return StatusCode(
+                StatusCodes.Status200OK,
+                ResponseApiService.Response(StatusCodes.Status200OK, result));
         }
         catch (ValidationException ex)
         {

--- a/Poliedro.Eds.Api/Program.cs
+++ b/Poliedro.Eds.Api/Program.cs
@@ -46,6 +46,8 @@ using Poliedro.Eds.Domain.FileUploadS3.Ports;
 using Poliedro.Eds.Domain.Inventory.DomainService;
 using Poliedro.Eds.Domain.Islander.DomainIslander;
 using Poliedro.Eds.Domain.SendMessage;
+using Poliedro.Eds.Application.TransferValidation.Commands.UpdateTransferValidation;
+using Poliedro.Eds.Application.TransferValidation.Validation;
 using Poliedro.Eds.Infraestructure.External.Keycloak.Services;
 using Poliedro.Eds.Infraestructure.External.Plemsi;
 using Poliedro.Eds.Infraestructure.Persistence.Mysql;
@@ -304,6 +306,11 @@ builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<Ba
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<BankGetAllQuery>());
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<CreateAccountCommand>());
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<GetAllAccountsQuery>());
+
+// === TRANSFER VALIDATION SERVICES ===
+builder.Services.AddScoped<TransferValidationCreateValidator>();
+builder.Services.AddScoped<UpdateTransferValidationValidator>();
+
 builder.Services.AddControllers();
 AwsSecretsDto secret = await AwsSecrets.GetSecret(builder.Configuration);
 

--- a/Poliedro.Eds.Application/TransferValidation/Commands/UpdateTransferValidation/UpdateTransferValidationCommand.cs
+++ b/Poliedro.Eds.Application/TransferValidation/Commands/UpdateTransferValidation/UpdateTransferValidationCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+using Poliedro.Eds.Application.TransferValidation.Dtos;
+
+namespace Poliedro.Eds.Application.TransferValidation.Commands.UpdateTransferValidation;
+
+public record UpdateTransferValidationCommand(
+    int Id,
+    UpdateTransferValidationRequestDto Request) : IRequest<TransferValidationDto>;

--- a/Poliedro.Eds.Application/TransferValidation/Commands/UpdateTransferValidation/UpdateTransferValidationCommandHandler.cs
+++ b/Poliedro.Eds.Application/TransferValidation/Commands/UpdateTransferValidation/UpdateTransferValidationCommandHandler.cs
@@ -1,0 +1,78 @@
+using AutoMapper;
+using FluentValidation;
+using FluentValidation.Results;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Poliedro.Eds.Application.TransferValidation.Dtos;
+using Poliedro.Eds.Domain.TransferValidation.Exceptions;
+using Poliedro.Eds.Domain.TransferValidation.Services;
+
+namespace Poliedro.Eds.Application.TransferValidation.Commands.UpdateTransferValidation;
+
+public class UpdateTransferValidationCommandHandler(
+    ITransferValidationService transferValidationService,
+    IMapper mapper,
+    UpdateTransferValidationValidator validator,
+    ILogger<UpdateTransferValidationCommandHandler> logger) 
+    : IRequestHandler<UpdateTransferValidationCommand, TransferValidationDto>
+{
+    public async Task<TransferValidationDto> Handle(
+        UpdateTransferValidationCommand request, 
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("=== INICIANDO ACTUALIZACIÓN DE VALIDACIÓN DE TRANSFERENCIA ===");
+        logger.LogInformation("ID: {Id}, Cliente: {CustomerName}, Monto: ${Amount:F2}", 
+            request.Id,
+            request.Request.CustomerName, 
+            request.Request.TransactionAmount);
+
+        // Validar el ID por separado
+        if (request.Id <= 0)
+        {
+            throw new ValidationException(new[]
+            {
+                new ValidationFailure("Id", "El ID de la validación de transferencia debe ser mayor a cero")
+            });
+        }
+
+        // Validar el request usando FluentValidation
+        await validator.ValidateAndThrowAsync(request.Request, cancellationToken);
+
+        try
+        {
+            // Llamar al servicio de dominio para actualizar la validación
+            var updated = await transferValidationService.UpdateAsync(
+                idTransferValidation: request.Id,
+                customerName: request.Request.CustomerName,
+                transactionAmount: request.Request.TransactionAmount,
+                transactionDate: request.Request.TransactionDate,
+                transactionTime: request.Request.TransactionTime,
+                status: request.Request.Status,
+                confirmedBy: request.Request.ConfirmedBy,
+                cancellationToken: cancellationToken);
+
+            logger.LogInformation("✅ Validación de transferencia actualizada exitosamente con ID: {Id}", 
+                updated.IdTransferValidation);
+            logger.LogInformation("=========================================================");
+
+            // Mapear la entidad al DTO de respuesta
+            return mapper.Map<TransferValidationDto>(updated);
+        }
+        catch (TransferValidationDomainException ex)
+        {
+            logger.LogError(ex, "❌ ERROR DE DOMINIO: {ErrorMessage}", ex.Message);
+            logger.LogInformation("=========================================================");
+            
+            throw new ValidationException(new[]
+            {
+                new ValidationFailure("TransferValidationDomain", ex.Message)
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "❌ ERROR INESPERADO: {ErrorMessage}", ex.Message);
+            logger.LogInformation("=========================================================");
+            throw;
+        }
+    }
+}

--- a/Poliedro.Eds.Application/TransferValidation/Commands/UpdateTransferValidation/UpdateTransferValidationRequestDto.cs
+++ b/Poliedro.Eds.Application/TransferValidation/Commands/UpdateTransferValidation/UpdateTransferValidationRequestDto.cs
@@ -1,0 +1,16 @@
+namespace Poliedro.Eds.Application.TransferValidation.Commands.UpdateTransferValidation;
+
+public class UpdateTransferValidationRequestDto
+{
+    public string CustomerName { get; set; } = null!;
+    
+    public double TransactionAmount { get; set; }
+    
+    public DateOnly TransactionDate { get; set; }
+    
+    public TimeOnly TransactionTime { get; set; }
+    
+    public string Status { get; set; } = null!;
+    
+    public string? ConfirmedBy { get; set; }
+}

--- a/Poliedro.Eds.Application/TransferValidation/Commands/UpdateTransferValidation/UpdateTransferValidationValidator.cs
+++ b/Poliedro.Eds.Application/TransferValidation/Commands/UpdateTransferValidation/UpdateTransferValidationValidator.cs
@@ -1,0 +1,46 @@
+using FluentValidation;
+using Poliedro.Eds.Domain.TransferValidation.ValueObjects;
+
+namespace Poliedro.Eds.Application.TransferValidation.Commands.UpdateTransferValidation;
+
+public class UpdateTransferValidationValidator : AbstractValidator<UpdateTransferValidationRequestDto>
+{
+    public UpdateTransferValidationValidator()
+    {
+        RuleFor(x => x.CustomerName)
+            .NotEmpty()
+            .WithMessage("El nombre del cliente es requerido")
+            .MaximumLength(150)
+            .WithMessage("El nombre del cliente no puede exceder 150 caracteres");
+
+        RuleFor(x => x.TransactionAmount)
+            .GreaterThan(0)
+            .WithMessage("El monto de la transacción debe ser mayor a cero")
+            .LessThanOrEqualTo(999999999.99)
+            .WithMessage("El monto de la transacción excede el límite permitido");
+
+        RuleFor(x => x.TransactionDate)
+            .NotEmpty()
+            .WithMessage("La fecha de la transacción es requerida")
+            .LessThanOrEqualTo(DateOnly.FromDateTime(DateTime.Now))
+            .WithMessage("La fecha de la transacción no puede ser futura");
+
+        RuleFor(x => x.TransactionTime)
+            .NotEmpty()
+            .WithMessage("La hora de la transacción es requerida");
+
+        RuleFor(x => x.Status)
+            .NotEmpty()
+            .WithMessage("El estado es requerido")
+            .Must(status => TransferValidationStatus.IsValid(status))
+            .WithMessage($"Estado inválido. Valores válidos: {string.Join(", ", TransferValidationStatus.GetValidStatuses())}");
+
+        RuleFor(x => x.ConfirmedBy)
+            .MaximumLength(255)
+            .WithMessage("El campo 'Confirmado por' no puede exceder 255 caracteres")
+            .NotEmpty()
+            .When(x => !string.IsNullOrWhiteSpace(x.Status) && 
+                      x.Status.Trim().ToUpperInvariant() == TransferValidationStatus.CONFIRMADA)
+            .WithMessage("Debe especificar quién confirmó la transacción cuando el estado es CONFIRMADA");
+    }
+}

--- a/Poliedro.Eds.Domain/TransferValidation/Repositories/ITransferValidationRepositoryGetById.cs
+++ b/Poliedro.Eds.Domain/TransferValidation/Repositories/ITransferValidationRepositoryGetById.cs
@@ -1,0 +1,10 @@
+using Poliedro.Eds.Domain.TransferValidation.Entities;
+
+namespace Poliedro.Eds.Domain.TransferValidation.Repositories;
+
+public interface ITransferValidationRepositoryGetById
+{
+    Task<TransferValidationEntity?> GetByIdAsync(
+        int idTransferValidation, 
+        CancellationToken cancellationToken = default);
+}

--- a/Poliedro.Eds.Domain/TransferValidation/Repositories/ITransferValidationRepositoryUpdate.cs
+++ b/Poliedro.Eds.Domain/TransferValidation/Repositories/ITransferValidationRepositoryUpdate.cs
@@ -1,0 +1,10 @@
+using Poliedro.Eds.Domain.TransferValidation.Entities;
+
+namespace Poliedro.Eds.Domain.TransferValidation.Repositories;
+
+public interface ITransferValidationRepositoryUpdate
+{
+    Task<TransferValidationEntity> UpdateAsync(
+        TransferValidationEntity entity, 
+        CancellationToken cancellationToken = default);
+}

--- a/Poliedro.Eds.Domain/TransferValidation/Services/ITransferValidationService.cs
+++ b/Poliedro.Eds.Domain/TransferValidation/Services/ITransferValidationService.cs
@@ -4,9 +4,18 @@ namespace Poliedro.Eds.Domain.TransferValidation.Services;
 
 public interface ITransferValidationService
 {
-
     Task<TransferValidationEntity> CreateAsync(
         string uniqueId,
+        string customerName,
+        double transactionAmount,
+        DateOnly transactionDate,
+        TimeOnly transactionTime,
+        string status,
+        string? confirmedBy,
+        CancellationToken cancellationToken = default);
+
+    Task<TransferValidationEntity> UpdateAsync(
+        int idTransferValidation,
         string customerName,
         double transactionAmount,
         DateOnly transactionDate,

--- a/Poliedro.Eds.Domain/TransferValidation/Services/TransferValidationService.cs
+++ b/Poliedro.Eds.Domain/TransferValidation/Services/TransferValidationService.cs
@@ -7,7 +7,9 @@ namespace Poliedro.Eds.Domain.TransferValidation.Services;
 
 public class TransferValidationService(
     ITransferValidationRepositoryCreate repositoryCreate,
-    ITransferValidationRepositoryGetByUniqueId repositoryGetByUniqueId) 
+    ITransferValidationRepositoryGetByUniqueId repositoryGetByUniqueId,
+    ITransferValidationRepositoryGetById repositoryGetById,
+    ITransferValidationRepositoryUpdate repositoryUpdate) 
     : ITransferValidationService
 {
     public async Task<TransferValidationEntity> CreateAsync(
@@ -67,5 +69,59 @@ public class TransferValidationService(
 
         // Persistir en la base de datos
         return await repositoryCreate.CreateAsync(entity, cancellationToken);
+    }
+
+    public async Task<TransferValidationEntity> UpdateAsync(
+        int idTransferValidation,
+        string customerName,
+        double transactionAmount,
+        DateOnly transactionDate,
+        TimeOnly transactionTime,
+        string status,
+        string? confirmedBy,
+        CancellationToken cancellationToken = default)
+    {
+        // Validaciones de negocio
+        if (idTransferValidation <= 0)
+            throw new TransferValidationDomainException("El ID de la validación de transferencia debe ser mayor a cero.");
+
+        if (string.IsNullOrWhiteSpace(customerName))
+            throw new TransferValidationDomainException("El nombre del cliente es requerido.");
+
+        if (transactionAmount <= 0)
+            throw new TransferValidationDomainException("El monto de la transacción debe ser mayor a cero.");
+
+        if (string.IsNullOrWhiteSpace(status))
+            throw new TransferValidationDomainException("El estado es requerido.");
+
+        var normalizedStatus = TransferValidationStatus.Normalize(status);
+
+        // Verificar que la entidad exista
+        var existingEntity = await repositoryGetById.GetByIdAsync(idTransferValidation, cancellationToken);
+        if (existingEntity == null)
+        {
+            throw new TransferValidationDomainException(
+                $"No se encontró la validación de transferencia con ID: {idTransferValidation}");
+        }
+
+        // Validar que si el estado es CONFIRMADA, debe haber un confirmedBy
+        if (normalizedStatus == TransferValidationStatus.CONFIRMADA && 
+            string.IsNullOrWhiteSpace(confirmedBy))
+        {
+            throw new TransferValidationDomainException(
+                "Si el estado es CONFIRMADA, debe especificar quién confirmó la transacción.");
+        }
+
+        // Actualizar la entidad existente
+        existingEntity.CustomerName = customerName.Trim();
+        existingEntity.TransactionAmount = transactionAmount;
+        existingEntity.TransactionDate = transactionDate;
+        existingEntity.TransactionTime = transactionTime;
+        existingEntity.Status = normalizedStatus;
+        existingEntity.ConfirmedBy = confirmedBy?.Trim();
+        existingEntity.UpdatedAt = DateTime.Now;
+
+        // Persistir los cambios
+        return await repositoryUpdate.UpdateAsync(existingEntity, cancellationToken);
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
@@ -231,6 +231,8 @@ public static class DependencyInjectionService
         // TransferValidation Services
         services.AddScoped<ITransferValidationRepositoryCreate, TransferValidationRepositoryCreate>();
         services.AddScoped<ITransferValidationRepositoryGetByUniqueId, TransferValidationRepositoryGetByUniqueId>();
+        services.AddScoped<ITransferValidationRepositoryGetById, TransferValidationRepositoryGetById>();
+        services.AddScoped<ITransferValidationRepositoryUpdate, TransferValidationRepositoryUpdate>();
         services.AddScoped<ITransferValidationService, TransferValidationService>();
 
         return services;

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/TransferValidation/Repositories/TransferValidationRepositoryGetById.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/TransferValidation/Repositories/TransferValidationRepositoryGetById.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Eds.Domain.TransferValidation.Entities;
+using Poliedro.Eds.Domain.TransferValidation.Repositories;
+using Poliedro.Eds.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.TransferValidation.Repositories;
+
+public class TransferValidationRepositoryGetById(ITenantDbContextFactory dbContextFactory) 
+    : ITransferValidationRepositoryGetById
+{
+    public async Task<TransferValidationEntity?> GetByIdAsync(
+        int idTransferValidation, 
+        CancellationToken cancellationToken = default)
+    {
+        using var context = dbContextFactory.CreateDbContext();
+        
+        return await context.TransferValidation
+            .AsNoTracking()
+            .FirstOrDefaultAsync(tv => tv.IdTransferValidation == idTransferValidation, cancellationToken);
+    }
+}

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/TransferValidation/Repositories/TransferValidationRepositoryUpdate.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/TransferValidation/Repositories/TransferValidationRepositoryUpdate.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Eds.Domain.TransferValidation.Entities;
+using Poliedro.Eds.Domain.TransferValidation.Repositories;
+using Poliedro.Eds.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Eds.Infraestructure.Persistence.Mysql.TransferValidation.Repositories;
+
+public class TransferValidationRepositoryUpdate(ITenantDbContextFactory dbContextFactory) 
+    : ITransferValidationRepositoryUpdate
+{
+    public async Task<TransferValidationEntity> UpdateAsync(
+        TransferValidationEntity entity, 
+        CancellationToken cancellationToken = default)
+    {
+        using var context = dbContextFactory.CreateDbContext();
+        
+        context.TransferValidation.Update(entity);
+        await context.SaveChangesAsync(cancellationToken);
+        
+        return entity;
+    }
+}

--- a/TransferValidationUpdateAPI.md
+++ b/TransferValidationUpdateAPI.md
@@ -1,0 +1,128 @@
+# Transfer Validation API Update Method
+
+## Overview
+The update method for the Transfer Validation API allows administrators to update existing transfer validation records in the system. The ID is passed as a query string parameter, while the data to update is sent in the request body.
+
+## Endpoint
+```
+PUT /api/v1/transfer-validation?id={id}
+```
+
+## Architecture Components Created
+
+### 1. **Command and DTOs**
+- `UpdateTransferValidationCommand.cs` - MediatR command (receives ID and request separately)
+- `UpdateTransferValidationRequestDto.cs` - Request DTO for the API (without ID)
+- `UpdateTransferValidationValidator.cs` - FluentValidation validator
+
+### 2. **Command Handler**
+- `UpdateTransferValidationCommandHandler.cs` - Handles the update logic with:
+  - ID validation (separate from request DTO)
+  - Request validation using FluentValidation
+  - Domain service integration
+  - Comprehensive logging
+  - Exception handling
+
+### 3. **Domain Services**
+- `ITransferValidationService.UpdateAsync()` - Domain service interface method
+- `TransferValidationService.UpdateAsync()` - Domain service implementation
+
+### 4. **Repositories**
+- `ITransferValidationRepositoryGetById.cs` - Interface for getting entity by ID
+- `ITransferValidationRepositoryUpdate.cs` - Interface for updating entities
+- `TransferValidationRepositoryGetById.cs` - Implementation for getting by ID
+- `TransferValidationRepositoryUpdate.cs` - Implementation for updating
+
+### 5. **Controller Method**
+- `UpdateTransferValidationController.Update()` - HTTP PUT endpoint with query string ID
+
+## Request Structure
+**URL**: `PUT /api/v1/transfer-validation?id=1`
+
+**Request Body**:
+```json
+{
+  "customerName": "Juan Pérez",
+  "transactionAmount": 150000.50,
+  "transactionDate": "2024-01-15",
+  "transactionTime": "14:30:00",
+  "status": "CONFIRMADA",
+  "confirmedBy": "admin@company.com"
+}
+```
+
+## Request Parameters
+### Query String Parameters
+- **id** (int, required): ID of the validation record to update
+
+### Request Body Properties
+- **customerName** (string, required): Customer name (max 150 chars)
+- **transactionAmount** (double, required): Transaction amount (> 0, <= 999999999.99)
+- **transactionDate** (DateOnly, required): Transaction date (not future)
+- **transactionTime** (TimeOnly, required): Transaction time
+- **status** (string, required): Status (PENDIENTE, CONFIRMADA, RECHAZADA)
+- **confirmedBy** (string, optional): Required when status is CONFIRMADA
+
+## Response Codes
+- **200 OK**: Update successful
+- **400 Bad Request**: Invalid ID or request parameters, validation errors
+- **401 Unauthorized**: Missing or invalid authentication
+- **404 Not Found**: Transfer validation record not found
+- **500 Internal Server Error**: Server error
+
+## Validation Rules
+### ID Validation (Query String)
+- ID must be greater than 0
+
+### Request Body Validation
+- Customer name is required and max 150 characters
+- Transaction amount must be > 0 and <= 999,999,999.99
+- Transaction date cannot be in the future
+- Status must be one of: PENDIENTE, CONFIRMADA, RECHAZADA
+- If status is CONFIRMADA, confirmedBy is required
+- ConfirmedBy max 255 characters
+
+## Architecture Changes for Query String ID
+The implementation was modified to separate the ID from the request body:
+
+1. **Controller** receives ID from `[FromQuery]` and data from `[FromBody]`
+2. **Command** takes ID as a separate parameter: `UpdateTransferValidationCommand(int Id, UpdateTransferValidationRequestDto Request)`
+3. **Command Handler** validates ID separately and uses it for domain service call
+4. **Request DTO** no longer contains the `IdTransferValidation` property
+5. **Validator** only validates the request body properties, not the ID
+
+## Sample API Call
+```bash
+curl -X PUT "https://api.example.com/api/v1/transfer-validation?id=123" \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer {token}" \
+-d '{
+  "customerName": "María García",
+  "transactionAmount": 250000.00,
+  "transactionDate": "2024-01-20",
+  "transactionTime": "09:15:00",
+  "status": "CONFIRMADA",
+  "confirmedBy": "supervisor@company.com"
+}'
+```
+
+## Error Examples
+### Invalid ID:
+```
+PUT /api/v1/transfer-validation?id=0
+Response: 400 Bad Request
+{
+  "error": "El ID de la validación de transferencia debe ser mayor a cero"
+}
+```
+
+### Entity Not Found:
+```
+PUT /api/v1/transfer-validation?id=999999
+Response: 404 Not Found
+{
+  "error": "No se encontró la validación de transferencia con ID: 999999"
+}
+```
+
+The implementation now cleanly separates the ID (passed via query string) from the update data (passed via request body), providing a more RESTful API design while maintaining all business validation and error handling capabilities.


### PR DESCRIPTION
### Checklist antes de hacer merge

- [x] Code compiles correctly  
- [x] Tests have been added  
- [x] Documentation has been updated  
- [x] Team has been informed about the changes

## Summary by Sourcery

Add full update capability for transfer validations across domain, application, API, and persistence layers, including business validation, MediatR command handling, FluentValidation rules, repository support, DI registration, and API documentation.

New Features:
- Add UpdateAsync to ITransferValidationService and implement business rules for updating transfer validations in TransferValidationService
- Introduce UpdateTransferValidationCommand, handler, request DTO, FluentValidation validator and MediatR integration for update operations
- Add HTTP PUT /api/v1/transfer-validation endpoint in TransferValidationController with Swagger documentation for updating transfer validation records

Enhancements:
- Register update validators and MediatR services in Program and persistence DI
- Add repository interfaces and implementations (GetById and Update) for transfer validation entities

Documentation:
- Add TransferValidationUpdateAPI.md with detailed API usage, request/response formats, and validation rules