### PR TITLE
Fix/documents

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,6 @@ README.md
 !.git/packed-refs
 !.git/refs/heads/**
 
-# Ignore worker service projects to prevent conflicts during API build
-WorkerKeycloackService/
-WorkerS3UploaderService/
+# Temporarily allow worker service projects for building worker containers
+# WorkerKeycloackService/
+# WorkerS3UploaderService/

--- a/Poliedro.Eds.Application/Court/AutoMappers/CourtMapper.cs
+++ b/Poliedro.Eds.Application/Court/AutoMappers/CourtMapper.cs
@@ -9,41 +9,49 @@ using Poliedro.Eds.Domain.Court.DomainService;
 using Poliedro.Eds.Domain.Court.Entities;
 using Poliedro.Eds.Domain.Inventory.Entities;
 
-namespace Poliedro.Eds.Application.Court.AutoMappers
+namespace Poliedro.Eds.Application.Court.AutoMappers;
+
+public class CourtMapper : Profile
 {
-    public class CourtMapper : Profile
+    public CourtMapper()
     {
-        public CourtMapper()
-        {
-            CreateMap<CourtEntity, CreateCourtCommand>().ReverseMap();
-            CreateMap<CourtEntity, UpdateCourtCommand>().ReverseMap();
-            CreateMap<CourtEntity, CourtDto>().ReverseMap();
-            CreateMap<CourtDispenserEntity, CourtDispenserDto>().ReverseMap();
-            CreateMap<DocumentEntity, DocumentDto>().ReverseMap();
-            CreateMap<CourtExpenditureEntity, CourtExpenditureDto>().ReverseMap();
-            CreateMap<CourtTypeOfCollectionEntity, CourtTypeOfCollectionDto>().ReverseMap();
-            CreateMap<CourtDispenserEntity, CourtDispenserCommand>().ReverseMap();
-            CreateMap<CourtExpenditureEntity, CourtExpenditureCommand>().ReverseMap();
-            CreateMap<DocumentEntity, DocumentCommand>().ReverseMap();
-            CreateMap<CourtExpenditureEntity, CourtExpenditureCommand>().ReverseMap();
-            CreateMap<CourtTypeOfCollectionEntity, CourtTypeOfCollectionCommand>().ReverseMap();
-            CreateMap<CourtDispenserEntity, CourtDispenserSaleEntity>()
-             .ForMember(dest => dest.IdCompartiment, opt => opt.MapFrom(src => src.IdCompartiment))
-             .ForMember(dest => dest.IdProduct, opt => opt.MapFrom(src => src.IdProduct));
-            CreateMap<CourtDispenserCommand, CourtDispenserSaleEntity>()
-             .ForMember(dest => dest.GallonsDifferenceResult, opt => opt.MapFrom(src => src.GallonsDifferenceResult));
+        CreateMap<CourtEntity, CreateCourtCommand>().ReverseMap();
+        CreateMap<CourtEntity, UpdateCourtCommand>().ReverseMap();
+        CreateMap<CourtEntity, CourtDto>().ReverseMap();
+        CreateMap<CourtDispenserEntity, CourtDispenserDto>().ReverseMap();
+        CreateMap<DocumentEntity, DocumentDto>().ReverseMap();
+        CreateMap<CourtExpenditureEntity, CourtExpenditureDto>().ReverseMap();
+        CreateMap<CourtTypeOfCollectionEntity, CourtTypeOfCollectionDto>().ReverseMap();
+        CreateMap<CourtDispenserEntity, CourtDispenserCommand>().ReverseMap();
+        CreateMap<CourtExpenditureEntity, CourtExpenditureCommand>().ReverseMap();
 
-            CreateMap<InventoryEntity, InventoryDto>().ReverseMap();
-            CreateMap<InventoryEntity, InventoryCommand>().ReverseMap();
+        // Fix the DocumentCommand to DocumentEntity mapping
+        CreateMap<DocumentCommand, DocumentEntity>()
+        .ForMember(dest => dest.Descripcion, opt => opt.MapFrom(src => src.Descripcion))
+        .ForMember(dest => dest.DocumentName, opt => opt.MapFrom(src => src.DocumentName))
+        .ForMember(dest => dest.IdCourtDocument, opt => opt.Ignore()) // Auto-generated
+        .ForMember(dest => dest.IdCourt, opt => opt.Ignore()); // Will be set by EF relationships
 
-            CreateMap<CourtCollectionViewEntity, CourtCollectionViewDto>().ReverseMap();
-            CreateMap<CourtDispenserViewEntity, CourtDispenserViewDto>().ReverseMap();
-            CreateMap<CourtDocumentViewEntity, CourtDocumentViewDto>().ReverseMap();
-            CreateMap<CourtExpenditureViewEntity, CourtExpenditureViewDto>().ReverseMap();
-            CreateMap<CourtListResponseEntity, CourtListResponseDto>();
-            CreateMap<CourtViewEntity, CourtViewDto>().ReverseMap();
+        CreateMap<DocumentEntity, DocumentCommand>()
+        .ForMember(dest => dest.Descripcion, opt => opt.MapFrom(src => src.Descripcion))
+             .ForMember(dest => dest.DocumentName, opt => opt.MapFrom(src => src.DocumentName));
 
+        CreateMap<CourtExpenditureEntity, CourtExpenditureCommand>().ReverseMap();
+        CreateMap<CourtTypeOfCollectionEntity, CourtTypeOfCollectionCommand>().ReverseMap();
+        CreateMap<CourtDispenserEntity, CourtDispenserSaleEntity>()
+         .ForMember(dest => dest.IdCompartiment, opt => opt.MapFrom(src => src.IdCompartiment))
+         .ForMember(dest => dest.IdProduct, opt => opt.MapFrom(src => src.IdProduct));
+        CreateMap<CourtDispenserCommand, CourtDispenserSaleEntity>()
+         .ForMember(dest => dest.GallonsDifferenceResult, opt => opt.MapFrom(src => src.GallonsDifferenceResult));
 
-        }
+        CreateMap<InventoryEntity, InventoryDto>().ReverseMap();
+        CreateMap<InventoryEntity, InventoryCommand>().ReverseMap();
+
+        CreateMap<CourtCollectionViewEntity, CourtCollectionViewDto>().ReverseMap();
+        CreateMap<CourtDispenserViewEntity, CourtDispenserViewDto>().ReverseMap();
+        CreateMap<CourtDocumentViewEntity, CourtDocumentViewDto>().ReverseMap();
+        CreateMap<CourtExpenditureViewEntity, CourtExpenditureViewDto>().ReverseMap();
+        CreateMap<CourtListResponseEntity, CourtListResponseDto>();
+        CreateMap<CourtViewEntity, CourtViewDto>().ReverseMap();
     }
 }

--- a/Poliedro.Eds.Application/Court/Dtos/DocumentDto.cs
+++ b/Poliedro.Eds.Application/Court/Dtos/DocumentDto.cs
@@ -3,9 +3,8 @@ namespace Poliedro.Eds.Application.Court.Dtos
     public class DocumentDto
     {
         public int IdCourtDocument { get; set; }
-
-        public string Descripcion { get; set; }
-
+        public string Descripcion { get; set; } = string.Empty;
+        public string? DocumentName { get; set; }
         public int IdCourt { get; set; }
     }
 }

--- a/Poliedro.Eds.Domain/Court/Entities/DocumentEntity.cs
+++ b/Poliedro.Eds.Domain/Court/Entities/DocumentEntity.cs
@@ -3,6 +3,7 @@ namespace Poliedro.Eds.Domain.Court.Entities;
 public class DocumentEntity
 {
     public int IdCourtDocument { get; set; }
-    public string Descripcion { get; set; }
+    public string Descripcion { get; set; } = string.Empty;
+    public string? DocumentName { get; set; }
     public int IdCourt { get; set; }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/CourtConfiguration.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/CourtConfiguration.cs
@@ -26,22 +26,25 @@ public class CourtConfiguration
         builder.HasOne(x => x.CourtInventory)
                 .WithOne()
                 .HasForeignKey<InventoryEntity>(x => x.ReferenceId);
+
         builder.HasMany(x => x.CourtDispensers)
                 .WithOne()
-                .HasForeignKey(x => x.IdCourt);
+                .HasForeignKey(x => x.IdCourt)
+                .OnDelete(DeleteBehavior.Cascade);
 
         builder.HasMany(x => x.CourtDocuments)
                 .WithOne()
-               .HasForeignKey(x => x.IdCourt);
+                .HasForeignKey(x => x.IdCourt)
+                .OnDelete(DeleteBehavior.Cascade);
 
         builder.HasMany(x => x.CourtExpenditures)
                .WithOne()
-               .HasForeignKey(x => x.IdCourt);
+               .HasForeignKey(x => x.IdCourt)
+               .OnDelete(DeleteBehavior.Cascade);
 
         builder.HasMany(x => x.CourtTypeOfCollections)
                .WithOne()
-               .HasForeignKey(x => x.IdCourt);
-
-
+               .HasForeignKey(x => x.IdCourt)
+               .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/DocumentConfiguration.cs
+++ b/Poliedro.Eds.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/DocumentConfiguration.cs
@@ -10,12 +10,22 @@ public class DocumentConfiguration
     {
         builder.ToTable("court_document");
         builder.HasKey(x => x.IdCourtDocument);
-        builder.Property(x => x.IdCourtDocument).HasColumnName("idcourt_document");
-        builder.Property(x => x.Descripcion).HasColumnName("descripcion");
+        builder.Property(x => x.IdCourtDocument).HasColumnName("idcourt_document")
+        .ValueGeneratedOnAdd();
+
+        builder.Property(x => x.Descripcion).HasColumnName("descripcion")
+          .HasColumnType("LONGTEXT")
+          .IsRequired();
+     
+        builder.Property(x => x.DocumentName).HasColumnName("document_name")
+            .HasMaxLength(100);
+   
         builder.Property(x => x.IdCourt).HasColumnName("id_court");
 
+     
         builder.HasOne<CourtEntity>()
             .WithMany(x => x.CourtDocuments)
-            .HasForeignKey(x => x.IdCourt);
+            .HasForeignKey(x => x.IdCourt)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/WorkerKeycloackService/appsettingsworker.json
+++ b/WorkerKeycloackService/appsettingsworker.json
@@ -14,7 +14,7 @@
         "DefaultGroupId": "b0244023-43b1-4f0d-97e0-c94b06f8f85d"
     },
   "RabbitMQ": {
-    "HostName": "3.136.23.237",
+    "HostName": "18.216.124.121",
     "UserName": "guest",
     "Password": "guest",
     "Queue": "keycloak"

--- a/WorkerS3UploaderService/Dockerfile
+++ b/WorkerS3UploaderService/Dockerfile
@@ -26,5 +26,5 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 # Copiar el appsettings.json específico del WorkerService
-COPY ["WorkerS3UploaderService/appsettings.json", "./appsettings.json"]
+COPY ["WorkerS3UploaderService/appsettingsS3.json", "./appsettings.json"]
 ENTRYPOINT ["dotnet", "WorkerS3UploaderService.dll"]

--- a/WorkerS3UploaderService/appsettingsS3.json
+++ b/WorkerS3UploaderService/appsettingsS3.json
@@ -11,7 +11,7 @@
     "FolderName": "carpeta"
   },
   "RabbitMQ": {
-    "HostName": "3.136.23.237",
+    "HostName": "18.216.124.121",
     "UserName": "guest",
     "Password": "guest",
     "QueueDocuments": "documents"


### PR DESCRIPTION
### Checklist antes de hacer merge

- [ ] Code compiles correctly  
- [ ] Tests have been added  
- [ ] Documentation has been updated  
- [ ] Team has been informed about the changes

## Summary by Sourcery

Implement DocumentName support, correct document mappings and EF configurations, enforce cascade deletes on court relationships, and update Dockerfile settings for WorkerS3UploaderService.

Bug Fixes:
- Fix DocumentCommand DocumentEntity AutoMapper mapping to correctly map Descripcion, DocumentName, and ignore auto-generated fields

Enhancements:
- Add DocumentName property to DocumentEntity and DocumentDto with default values
- Enhance DocumentEntity EF configuration: auto-generate primary key, enforce LONGTEXT for Descripcion, constrain DocumentName length, and cascade delete on court relationship
- Enable cascade delete behavior on Court entity relationships for dispensers, documents, expenditures, and collection types

Build:
- Update WorkerS3UploaderService Dockerfile to copy the correct appsettingsS3.json file