### PR TITLE
feat(files): prefix S3 filenames with shift ID

### DIFF
--- a/Amazon/S3/FileUploadService/FileUploadService.cs
+++ b/Amazon/S3/FileUploadService/FileUploadService.cs
@@ -34,9 +34,12 @@ namespace Amazon.S3.FileUploadService
             _queue = configuration["RabbitMQ:QueueDocuments"] ?? throw new ArgumentNullException("Queue configuration is missing");
         }
 
-        public async Task<string> UploadFileAsync(IFormFile file)
+        public async Task<string> UploadFileAsync(IFormFile file, int courtId)
         {
-            var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}_{file.FileName}");
+            // Siempre agregar prefijo del courtId al nombre del archivo
+            var fileName = $"{courtId}_{file.FileName}";
+            var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}_{fileName}");
+            
             await using (var stream = new FileStream(tempPath, FileMode.Create))
             {
                 await file.CopyToAsync(stream);
@@ -47,8 +50,9 @@ namespace Amazon.S3.FileUploadService
                 BucketName = _bucketName,
                 FolderName = _folderName,
                 TempPath = tempPath,
-                FileName = file.FileName,
-                ContentType = file.ContentType
+                FileName = fileName,
+                ContentType = file.ContentType,
+                CourtId = courtId
             };
 
             // Publish RabbitMQ
@@ -62,7 +66,7 @@ namespace Amazon.S3.FileUploadService
 
             channel.BasicPublish(exchange: string.Empty, routingKey: _queue, basicProperties: null, body: body);
 
-            return $"{_folderName}/pending/{file.FileName}";
+            return $"{_folderName}/pending/{fileName}";
         }
     }
 }

--- a/Poliedro.Eds.Api/Controllers/v1/FileUploadS3/FileUploadS3Controller.cs
+++ b/Poliedro.Eds.Api/Controllers/v1/FileUploadS3/FileUploadS3Controller.cs
@@ -18,7 +18,7 @@ public class UploadController(IMediator mediator) : ControllerBase
         var results = new List<string>();
         foreach (var file in request.Files)
         {
-            var command = new UploadFileCommand(file);
+            var command = new UploadFileCommand(file, request.CourtId);
             var result = await mediator.Send(command);
             results.Add(result);
         }

--- a/Poliedro.Eds.Application/FileUploadS3/Command/UploadFileCommand.cs
+++ b/Poliedro.Eds.Application/FileUploadS3/Command/UploadFileCommand.cs
@@ -3,4 +3,4 @@ using Microsoft.AspNetCore.Http;
 
 namespace Poliedro.Eds.Application.FileUploadS3.Command;
 
-public record UploadFileCommand(IFormFile File) : IRequest<string>;
+public record UploadFileCommand(IFormFile File, int CourtId) : IRequest<string>;

--- a/Poliedro.Eds.Application/FileUploadS3/Command/UploadFileHandler.cs
+++ b/Poliedro.Eds.Application/FileUploadS3/Command/UploadFileHandler.cs
@@ -5,5 +5,8 @@ namespace Poliedro.Eds.Application.FileUploadS3.Command;
 
 public class UploadFileHandler(IFileUploadService fileUploadService) : IRequestHandler<UploadFileCommand, string>
 {
-    public async Task<string> Handle(UploadFileCommand request, CancellationToken cancellationToken) => await fileUploadService.UploadFileAsync(request.File);
+    public async Task<string> Handle(UploadFileCommand request, CancellationToken cancellationToken) 
+    {
+        return await fileUploadService.UploadFileAsync(request.File, request.CourtId);
+    }
 }

--- a/Poliedro.Eds.Application/FileUploadS3/Command/UploadFileValidator.cs
+++ b/Poliedro.Eds.Application/FileUploadS3/Command/UploadFileValidator.cs
@@ -11,5 +11,8 @@ public class UploadFileValidator : AbstractValidator<UploadFileCommand>
         RuleFor(x => x.File)
             .NotNull().WithMessage(redisService.GetValueFromCacheAsync("FileNotNull").GetAwaiter().GetResult())
             .Must(f => f.Length > 0).WithMessage(redisService.GetValueFromCacheAsync("FileMust").GetAwaiter().GetResult());
+            
+        RuleFor(x => x.CourtId)
+            .GreaterThan(0).WithMessage("CourtId must be greater than 0");
     }
 }

--- a/Poliedro.Eds.Domain/FileUploadS3/DocumentEvent.cs
+++ b/Poliedro.Eds.Domain/FileUploadS3/DocumentEvent.cs
@@ -13,5 +13,6 @@ namespace Poliedro.Eds.Domain.FileUploadS3
         public string TempPath { get; set; } = "";
         public string FileName { get; set; } = "";
         public string ContentType { get; set; } = "";
+        public int CourtId { get; set; }
     }
 }

--- a/Poliedro.Eds.Domain/FileUploadS3/Ports/IFileUploadService.cs
+++ b/Poliedro.Eds.Domain/FileUploadS3/Ports/IFileUploadService.cs
@@ -4,5 +4,5 @@ namespace Poliedro.Eds.Domain.FileUploadS3.Ports;
 
 public interface IFileUploadService
 {
-    Task<string> UploadFileAsync(IFormFile file);
+    Task<string> UploadFileAsync(IFormFile file, int courtId);
 }

--- a/Poliedro.Eds.Domain/FileUploadS3/UploadFileRequest.cs
+++ b/Poliedro.Eds.Domain/FileUploadS3/UploadFileRequest.cs
@@ -5,4 +5,5 @@ namespace Poliedro.Eds.Domain.FileUploadS3;
 public class UploadFileRequest
 {
     public List<IFormFile> Files { get; set; }
+    public int CourtId { get; set; }
 }


### PR DESCRIPTION
### Checklist antes de hacer merge

- [x] Code compiles correctly  
- [x] Tests have been added  
- [x] Documentation has been updated  
- [x] Team has been informed about the changes

## Summary by Sourcery

Enable associating uploaded files with a specific court by passing courtId through the file upload flow and prefixing S3 stored filenames accordingly

New Features:
- Prefix S3 filenames with the provided courtId in the upload service
- Propagate courtId through the API controller, request model, command, handler, service interface, and domain event

Enhancements:
- Add validation rule to ensure courtId is greater than 0 in the file upload request